### PR TITLE
hardening: stabilize MCP runtime contracts and degraded memory behavior

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -196,3 +196,9 @@ NGINX_HTTPS_PORT=443
 
 # Paperclip Port (used by Next.js app)
 PAPERCLIP_PORT=3100
+
+# Canonical MCP HTTP Gateway Port
+ALLURA_MCP_HTTP_PORT=3201
+
+# Legacy OpenClaw Gateway Port (deprecated)
+OPENCLAW_PORT=3200

--- a/Dockerfile.mcp
+++ b/Dockerfile.mcp
@@ -1,0 +1,13 @@
+FROM oven/bun:1 AS base
+
+WORKDIR /app
+
+COPY package.json ./
+COPY tsconfig.json ./
+COPY src ./src
+
+RUN bun install
+
+ENV NODE_ENV=production
+
+CMD ["bun", "src/mcp/memory-server-canonical.ts"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,7 @@ services:
       OLLAMA_API_KEY: ${OLLAMA_API_KEY}
       OLLAMA_CLOUD_URL: ${OLLAMA_CLOUD_URL:-https://ollama.com}
     healthcheck:
-      test: ["CMD-SHELL", "bun -e 'fetch(\"http://localhost:3100/api/health\").then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))'"]
+      test: ["CMD", "pgrep", "-f", "memory-server-canonical"]
       interval: 30s
       timeout: 10s
       start_period: 15s

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -63,7 +63,7 @@ services:
   mcp:
     build:
       context: ..
-      dockerfile: docker/Dockerfile.prod
+      dockerfile: Dockerfile.mcp
     container_name: allura-memory-mcp
     restart: unless-stopped
     depends_on:
@@ -84,7 +84,7 @@ services:
       OLLAMA_API_KEY: ${OLLAMA_API_KEY}
       OLLAMA_CLOUD_URL: ${OLLAMA_CLOUD_URL:-https://ollama.com}
     healthcheck:
-      test: ["CMD", "pgrep", "-f", "memory-server"]
+      test: ["CMD", "pgrep", "-f", "memory-server-canonical"]
       interval: 30s
       timeout: 10s
       start_period: 15s

--- a/docs/allura/RISKS-AND-DECISIONS.md
+++ b/docs/allura/RISKS-AND-DECISIONS.md
@@ -25,6 +25,7 @@
 | AD-11 | Human-in-the-loop gating for validation evidence | Decided | Every RalphLoop slice requires human review before proceeding. Judge reviews all evidence; no automatic progression to next slice without explicit approval. |
 | AD-12 | Slice-by-slice approach (no parallel slice definition) | Decided | Sequential slice execution ensures clear causation and evidence trails. Parallel slices would introduce race conditions and obscure failure attribution. |
 | AD-13 | Canonical API validation uses bounded RalphLoop slices | Decided | Validate `/api/memory` with bounded, repeatable slices to preserve fast feedback, clear causality, and low architectural risk. |
+| AD-14 | PostgreSQL required, Neo4j degradable at runtime | Decided | Canonical memory contract remains available when PostgreSQL is healthy. Neo4j is optional-at-runtime: failures must surface explicit degraded metadata in health and tool responses rather than causing silent partial success or full outage. |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "mcp": "bun src/mcp/memory-server-canonical.ts",
     "mcp:canonical": "bun src/mcp/memory-server-canonical.ts",
     "mcp:dev": "bun --watch src/mcp/memory-server-canonical.ts",
-    "mcp:http": "PORT=${CANONICAL_HTTP_PORT:-3201} bun src/mcp/canonical-http-gateway.ts",
+    "mcp:http": "ALLURA_MCP_HTTP_PORT=${ALLURA_MCP_HTTP_PORT:-${CANONICAL_HTTP_PORT:-${OPENCLAW_PORT:-3201}}} bun src/mcp/canonical-http-gateway.ts",
     "mcp:legacy": "bun src/mcp/legacy/memory-server.ts",
     "mcp:legacy:http": "PORT=${OPENCLAW_PORT:-3200} bun src/mcp/legacy/openclaw-gateway-http.ts",
     "curator:run": "bun src/curator/index.ts run",

--- a/scripts/check-ports.ts
+++ b/scripts/check-ports.ts
@@ -9,7 +9,7 @@ import { getPortConfig, isPortAvailable, PORT_RANGES } from "../src/lib/config/p
 
 const REQUIRED_PORTS = [
   { name: "Paperclip (Next.js)", key: "paperclip" as const },
-  { name: "OpenClaw Gateway", key: "openclaw" as const },
+  { name: "Canonical MCP HTTP Gateway", key: "mcp_http" as const },
   { name: "PostgreSQL", key: "postgres" as const },
   { name: "Neo4j HTTP", key: "neo4j_http" as const },
   { name: "Neo4j Bolt", key: "neo4j_bolt" as const },
@@ -27,7 +27,14 @@ async function checkPorts() {
     const available = await isPortAvailable(port);
     
     const status = available ? "✅" : "❌";
-    const portSource = process.env[`${key.toUpperCase()}_PORT`] ? "(from env)" : "(default)";
+    const portSource =
+      key === "mcp_http"
+        ? process.env.ALLURA_MCP_HTTP_PORT
+          ? "(from ALLURA_MCP_HTTP_PORT)"
+          : "(default)"
+        : process.env[`${key.toUpperCase()}_PORT`]
+          ? "(from env)"
+          : "(default)";
     
     console.log(`${status} ${name}: port ${port} ${portSource}`);
     
@@ -44,14 +51,14 @@ async function checkPorts() {
     console.log("✅ All ports are available!");
     console.log("\nTo start services:");
     console.log("  bun run dev          # Start Paperclip on port", config.paperclip);
-    console.log("  bun run mcp:http     # Start OpenClaw on port", config.openclaw);
+     console.log("  bun run mcp:http     # Start canonical MCP HTTP gateway on port", config.mcp_http);
     process.exit(0);
   } else {
     console.log("❌ Some ports are in use.");
     console.log("\nOptions:");
     console.log("  1. Stop conflicting services");
     console.log("  2. Set environment variables to use different ports:");
-    console.log("     PAPERCLIP_PORT=3101 OPENCLAW_PORT=3201 bun run dev");
+     console.log("     PAPERCLIP_PORT=3101 ALLURA_MCP_HTTP_PORT=3202 bun run dev");
     console.log("  3. Generate random ports:");
     console.log("     bun run ports:generate >> .env.local");
     process.exit(1);

--- a/scripts/launch-openclaw.sh
+++ b/scripts/launch-openclaw.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 # OpenClaw Gateway Launcher
 cd "/home/ronin704/Projects/allura memory" || exit 1
-export PORT=3200
-echo "🦾 Starting OpenClaw Gateway on port $PORT"
-echo "📡 Health: http://localhost:$PORT/health"
-echo "🔧 Tools: http://localhost:$PORT/tools"
+export ALLURA_MCP_HTTP_PORT="${ALLURA_MCP_HTTP_PORT:-${OPENCLAW_PORT:-3201}}"
+echo "🦾 Starting canonical MCP HTTP gateway on port $ALLURA_MCP_HTTP_PORT"
+echo "📡 Health: http://localhost:$ALLURA_MCP_HTTP_PORT/health"
+echo "🔧 Tools: http://localhost:$ALLURA_MCP_HTTP_PORT/tools"
 echo ""
 bun run mcp:http

--- a/scripts/openclaw-onboard.ts
+++ b/scripts/openclaw-onboard.ts
@@ -142,8 +142,8 @@ async function main(): Promise<void> {
 
   // Done
   console.log("✅ Onboarding complete!\n");
-  console.log("🚀 Start OpenClaw gateway:");
-  console.log(`   PORT=${OPENCLAW_PORT} bun run mcp:http\n`);
+  console.log("🚀 Start canonical MCP HTTP gateway:");
+  console.log(`   ALLURA_MCP_HTTP_PORT=${OPENCLAW_PORT} bun run mcp:http\n`);
   console.log("📡 Test the gateway:");
   console.log(`   curl http://localhost:${OPENCLAW_PORT}/health | jq .\n`);
   console.log("🔧 Available tools:");

--- a/scripts/setup-telegram.ts
+++ b/scripts/setup-telegram.ts
@@ -8,7 +8,10 @@ import { getPool } from "../src/lib/postgres/connection";
 
 config();
 
-const OPENCLAW_PORT = parseInt(process.env.OPENCLAW_PORT || "3200", 10);
+const MCP_HTTP_PORT = parseInt(
+  process.env.ALLURA_MCP_HTTP_PORT || process.env.OPENCLAW_PORT || "3201",
+  10
+);
 
 interface TelegramConfig {
   botToken: string;
@@ -83,7 +86,7 @@ async function main(): Promise<void> {
   
   console.log("\n🤖 Telegram Channel Setup for OpenClaw\n");
   console.log(`   Group: ${groupId}`);
-  console.log(`   Gateway: http://localhost:${OPENCLAW_PORT}\n`);
+  console.log(`   Gateway: http://localhost:${MCP_HTTP_PORT}\n`);
 
   const botToken = process.env.TELEGRAM_BOT_TOKEN;
 
@@ -101,7 +104,7 @@ async function main(): Promise<void> {
 
   const config: TelegramConfig = {
     botToken,
-    webhookUrl: process.env.TELEGRAM_WEBHOOK_URL || `http://localhost:${OPENCLAW_PORT}/webhook/telegram`,
+    webhookUrl: process.env.TELEGRAM_WEBHOOK_URL || `http://localhost:${MCP_HTTP_PORT}/webhook/telegram`,
   };
 
   console.log("\n💾 Saving Telegram channel configuration...");

--- a/scripts/setup-whatsapp.ts
+++ b/scripts/setup-whatsapp.ts
@@ -10,7 +10,10 @@ import { getPool } from "../src/lib/postgres/connection";
 
 config();
 
-const OPENCLAW_PORT = parseInt(process.env.OPENCLAW_PORT || "3200", 10);
+const MCP_HTTP_PORT = parseInt(
+  process.env.ALLURA_MCP_HTTP_PORT || process.env.OPENCLAW_PORT || "3201",
+  10
+);
 
 interface WhatsAppConfig {
   phoneNumberId: string;
@@ -77,8 +80,8 @@ async function testWhatsAppConnection(config: WhatsAppConfig): Promise<boolean> 
 }
 
 async function getWebhookUrl(): Promise<string> {
-  // Use OPENCLAW_PORT or default
-  const port = OPENCLAW_PORT;
+  // Use canonical MCP HTTP port, then legacy fallback
+  const port = MCP_HTTP_PORT;
   const host = process.env.OPENCLAW_HOST || 'localhost';
   
   // For local development, use ngrok or similar tunnel
@@ -88,7 +91,7 @@ async function getWebhookUrl(): Promise<string> {
     console.log('\n📡 WhatsApp requires a public webhook URL for local development.');
     console.log('   Use ngrok or similar tunnel:\n');
     console.log('   1. Install: npm install -g ngrok');
-    console.log('   2. Run: ngrok http 3200');
+    console.log('   2. Run: ngrok http 3201');
     console.log('   3. Copy the HTTPS URL (e.g., https://abc123.ngrok.io)');
     console.log('   4. Set WHATSAPP_WEBHOOK_URL in .env.local\n');
     return process.env.WHATSAPP_WEBHOOK_URL || '';
@@ -132,7 +135,7 @@ function printSetupInstructions(): void {
   console.log('STEP 6: Test Webhook (Local Development)\n');
   console.log('   For local testing, use ngrok:');
   console.log('   npm install -g ngrok');
-  console.log('   ngrok http 3200');
+  console.log('   ngrok http 3201');
   console.log('   # Copy HTTPS URL to WHATSAPP_WEBHOOK_URL\n');
   
   console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n');
@@ -143,7 +146,7 @@ async function main(): Promise<void> {
   
   console.log("\n📱 WhatsApp Channel Setup for OpenClaw\n");
   console.log(`   Group: ${groupId}`);
-  console.log(`   Gateway: http://localhost:${OPENCLAW_PORT}\n`);
+  console.log(`   Gateway: http://localhost:${MCP_HTTP_PORT}\n`);
 
   // Check for environment variables
   const phoneNumberId = process.env.WHATSAPP_PHONE_NUMBER_ID;

--- a/scripts/test-whatsapp-integration.ts
+++ b/scripts/test-whatsapp-integration.ts
@@ -10,8 +10,11 @@ import { config } from "dotenv";
 
 config();
 
-const OPENCLAW_PORT = parseInt(process.env.OPENCLAW_PORT || "3200", 10);
-const BASE_URL = `http://localhost:${OPENCLAW_PORT}`;
+const MCP_HTTP_PORT = parseInt(
+  process.env.ALLURA_MCP_HTTP_PORT || process.env.OPENCLAW_PORT || "3201",
+  10
+);
+const BASE_URL = `http://localhost:${MCP_HTTP_PORT}`;
 
 interface TestResult {
   name: string;

--- a/src/__tests__/canonical-memory.test.ts
+++ b/src/__tests__/canonical-memory.test.ts
@@ -12,6 +12,7 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import { randomUUID } from "crypto";
 import {
   memory_add,
   memory_search,
@@ -28,11 +29,22 @@ import type {
 } from "../lib/memory/canonical-contracts";
 
 // Test configuration
-const TEST_GROUP_ID = "allura-test-canonical" as any;
+const RUN_ID = randomUUID().slice(0, 8);
+const TEST_GROUP_ID = `allura-test-canonical-${RUN_ID}` as any;
 const TEST_USER_ID = "test-user-1";
 const TEST_USER_ID_2 = "test-user-2";
+const GROUP_A = `allura-tenant-a-${RUN_ID}` as any;
+const GROUP_B = `allura-tenant-b-${RUN_ID}` as any;
+
+function uniqueContent(base: string): string {
+  return `${base} [run:${RUN_ID}] [id:${randomUUID().slice(0, 8)}]`;
+}
 
 describe("Canonical Memory Operations", () => {
+  beforeEach(() => {
+    process.env.PROMOTION_MODE = "soc2";
+  });
+
   beforeAll(async () => {
     // Setup: Ensure databases are running
     // TODO: Add database health check
@@ -72,7 +84,7 @@ describe("Canonical Memory Operations", () => {
          const request: MemoryAddRequest = {
            group_id: TEST_GROUP_ID,
            user_id: TEST_USER_ID,
-           content: "User prefers dark theme in VS Code editor settings", // Unique content
+          content: uniqueContent("User prefers dark theme in VS Code editor settings"),
            metadata: { source: "conversation" },
          };
 
@@ -97,7 +109,7 @@ describe("Canonical Memory Operations", () => {
         const request: MemoryAddRequest = {
           group_id: TEST_GROUP_ID,
           user_id: TEST_USER_ID,
-          content: "User works with TypeScript strict mode enabled in their IDE", // Unique content
+          content: uniqueContent("User works with TypeScript strict mode enabled in their IDE"),
           metadata: { source: "conversation" },
         };
 
@@ -138,14 +150,14 @@ describe("Canonical Memory Operations", () => {
       await memory_add({
         group_id: TEST_GROUP_ID,
         user_id: TEST_USER_ID,
-        content: "User prefers dark mode",
+        content: uniqueContent("User prefers dark mode"),
         metadata: { source: "manual" },
       });
 
       await memory_add({
         group_id: TEST_GROUP_ID,
         user_id: TEST_USER_ID,
-        content: "User uses TypeScript",
+        content: uniqueContent("User uses TypeScript"),
         metadata: { source: "conversation" },
       });
     });
@@ -214,7 +226,7 @@ describe("Canonical Memory Operations", () => {
       const response = await memory_add({
         group_id: TEST_GROUP_ID,
         user_id: TEST_USER_ID,
-        content: "Test memory for get operation",
+        content: uniqueContent("Test memory for get operation"),
         metadata: { source: "manual" },
       });
       testMemoryId = response.id;
@@ -229,7 +241,7 @@ describe("Canonical Memory Operations", () => {
       const response = await memory_get(request);
 
       expect(response.id).toBe(testMemoryId);
-      expect(response.content).toBe("Test memory for get operation");
+      expect(response.content).toContain("Test memory for get operation");
       expect(response.source).toBeDefined();
       expect(response.provenance).toBe("manual");
       expect(response.created_at).toBeDefined();
@@ -260,21 +272,21 @@ describe("Canonical Memory Operations", () => {
       await memory_add({
         group_id: TEST_GROUP_ID,
         user_id: TEST_USER_ID,
-        content: "Memory 1 for user 1",
+        content: uniqueContent("Memory 1 for user 1"),
         metadata: { source: "manual" },
       });
 
       await memory_add({
         group_id: TEST_GROUP_ID,
         user_id: TEST_USER_ID,
-        content: "Memory 2 for user 1",
+        content: uniqueContent("Memory 2 for user 1"),
         metadata: { source: "conversation" },
       });
 
       await memory_add({
         group_id: TEST_GROUP_ID,
         user_id: TEST_USER_ID_2,
-        content: "Memory 1 for user 2",
+        content: uniqueContent("Memory 1 for user 2"),
         metadata: { source: "manual" },
       });
     });
@@ -334,10 +346,10 @@ describe("Canonical Memory Operations", () => {
 
     beforeEach(async () => {
       // Add a test memory
-      const response = await memory_add({
-        group_id: TEST_GROUP_ID,
-        user_id: TEST_USER_ID,
-        content: "Test memory for delete operation",
+        const response = await memory_add({
+          group_id: TEST_GROUP_ID,
+          user_id: TEST_USER_ID,
+          content: uniqueContent("Test memory for delete operation"),
         metadata: { source: "manual" },
       });
       testMemoryId = response.id;
@@ -367,7 +379,7 @@ describe("Canonical Memory Operations", () => {
         const addResponse = await memory_add({
           group_id: TEST_GROUP_ID,
           user_id: TEST_USER_ID,
-          content: "User prefers dark mode for deletion test",
+          content: uniqueContent("User prefers dark mode for deletion test"),
           metadata: { source: "conversation" },
         });
 
@@ -397,25 +409,23 @@ describe("Canonical Memory Operations", () => {
   });
 
   describe("Tenant Isolation", () => {
-    const GROUP_A = "allura-tenant-a" as any;
-    const GROUP_B = "allura-tenant-b" as any;
     const USER_A = "user-a";
     const USER_B = "user-b";
 
     it("should isolate memories by group_id", async () => {
       // Add memory for Group A
-      await memory_add({
-        group_id: GROUP_A,
-        user_id: USER_A,
-        content: "Memory for Group A",
+        await memory_add({
+          group_id: GROUP_A,
+          user_id: USER_A,
+          content: uniqueContent("Memory for Group A"),
         metadata: { source: "manual" },
       });
 
       // Add memory for Group B
-      await memory_add({
-        group_id: GROUP_B,
-        user_id: USER_B,
-        content: "Memory for Group B",
+        await memory_add({
+          group_id: GROUP_B,
+          user_id: USER_B,
+          content: uniqueContent("Memory for Group B"),
         metadata: { source: "manual" },
       });
 
@@ -441,10 +451,10 @@ describe("Canonical Memory Operations", () => {
 
     it("should prevent cross-tenant memory access", async () => {
       // Add memory for Group A
-      const addResponse = await memory_add({
-        group_id: GROUP_A,
-        user_id: USER_A,
-        content: "Private memory for Group A",
+        const addResponse = await memory_add({
+          group_id: GROUP_A,
+          user_id: USER_A,
+          content: uniqueContent("Private memory for Group A"),
         metadata: { source: "manual" },
       });
 
@@ -467,7 +477,7 @@ describe("Canonical Memory Operations", () => {
         const response = await memory_add({
           group_id: TEST_GROUP_ID,
           user_id: TEST_USER_ID,
-          content: "User prefers dark mode in VS Code editor and terminal window", // Unique content
+          content: uniqueContent("User prefers dark mode in VS Code editor and terminal window"),
           metadata: { source: "conversation" },
         });
 
@@ -486,7 +496,7 @@ describe("Canonical Memory Operations", () => {
         const response = await memory_add({
           group_id: TEST_GROUP_ID,
           user_id: TEST_USER_ID,
-          content: "User works in TypeScript with strict mode and很喜欢 TypeScript", // Unique content
+          content: uniqueContent("User works in TypeScript with strict mode and very much enjoys TypeScript"),
           metadata: { source: "conversation" },
         });
 

--- a/src/__tests__/canonical-memory.test.ts
+++ b/src/__tests__/canonical-memory.test.ts
@@ -124,6 +124,30 @@ describe("Canonical Memory Operations", () => {
       }
     });
 
+    it("should return episodic storage with degraded metadata when auto promotion cannot reach Neo4j", async () => {
+      const originalMode = process.env.PROMOTION_MODE;
+      const originalNeo4jUri = process.env.NEO4J_URI;
+      process.env.PROMOTION_MODE = "auto";
+      process.env.NEO4J_URI = "bolt://127.0.0.1:1";
+
+      try {
+        const response = await memory_add({
+          group_id: TEST_GROUP_ID,
+          user_id: TEST_USER_ID,
+          content: uniqueContent("User prefers deterministic degraded auto promotion behavior"),
+          metadata: { source: "conversation" },
+        });
+
+        expect(response.stored).toBe("episodic");
+        expect(response.meta?.degraded).toBe(true);
+        expect(response.meta?.degraded_reason).toBe("neo4j_unavailable");
+        expect(response.meta?.stores_used).toEqual(["postgres"]);
+      } finally {
+        process.env.PROMOTION_MODE = originalMode;
+        process.env.NEO4J_URI = originalNeo4jUri;
+      }
+    });
+
     it("should reject invalid group_id", async () => {
       const request: MemoryAddRequest = {
         group_id: "invalid-group-id" as any, // Missing 'allura-' prefix

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -10,6 +10,8 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
+import { Pool } from 'pg';
+import neo4j from 'neo4j-driver';
 
 /**
  * Health status for a component
@@ -30,6 +32,17 @@ export interface HealthResponse {
   timestamp: string;
   uptime: number;
   version: string;
+  mode?: 'http';
+  interface?: 'rest';
+  dependencies?: {
+    postgres: { status: 'up' | 'down'; required: true; latency_ms?: number };
+    neo4j: { status: 'up' | 'down'; required: false; latency_ms?: number };
+  };
+  degraded?: {
+    enabled: boolean;
+    reason?: 'neo4j_unavailable';
+    capabilities_lost?: string[];
+  };
   components?: ComponentHealth[];
 }
 
@@ -40,11 +53,17 @@ async function checkPostgreSQL(): Promise<ComponentHealth> {
   const start = Date.now();
   
   try {
-    // In production, this would check actual PostgreSQL connection
-    // For now, return a mock healthy status
-    
-    // TODO: Implement actual PostgreSQL connection check
-    // const result = await postgresClient.query('SELECT 1');
+    const pool = new Pool({
+      host: process.env.POSTGRES_HOST || 'localhost',
+      port: parseInt(process.env.POSTGRES_PORT || '5432', 10),
+      database: process.env.POSTGRES_DB || 'memory',
+      user: process.env.POSTGRES_USER || 'ronin4life',
+      password: process.env.POSTGRES_PASSWORD,
+      connectionTimeoutMillis: 5000,
+      max: 1,
+    });
+    await pool.query('SELECT 1');
+    await pool.end();
     
     return {
       name: 'postgresql',
@@ -52,7 +71,6 @@ async function checkPostgreSQL(): Promise<ComponentHealth> {
       message: 'Database connection verified',
       latency: Date.now() - start,
       details: {
-        // In production: actual connection pool stats
         connected: true,
       },
     };
@@ -78,11 +96,17 @@ async function checkNeo4j(): Promise<ComponentHealth> {
   const start = Date.now();
   
   try {
-    // In production, this would check actual Neo4j connection
-    // For now, return a mock healthy status
-    
-    // TODO: Implement actual Neo4j connection check
-    // const result = await neo4jClient.run('RETURN 1 AS test');
+    const driver = neo4j.driver(
+      process.env.NEO4J_URI || 'bolt://localhost:7687',
+      neo4j.auth.basic(
+        process.env.NEO4J_USER || 'neo4j',
+        process.env.NEO4J_PASSWORD || 'password'
+      )
+    );
+    const session = driver.session();
+    await session.run('RETURN 1 AS test');
+    await session.close();
+    await driver.close();
     
     return {
       name: 'neo4j',
@@ -90,7 +114,6 @@ async function checkNeo4j(): Promise<ComponentHealth> {
       message: 'Graph database connection verified',
       latency: Date.now() - start,
       details: {
-        // In production: actual connection stats
         connected: true,
       },
     };
@@ -263,14 +286,18 @@ async function checkDiskSpace(): Promise<ComponentHealth> {
  * Get overall health status from component healths
  */
 function getOverallStatus(components: ComponentHealth[]): 'healthy' | 'degraded' | 'unhealthy' {
-  const unhealthyCount = components.filter(c => c.status === 'unhealthy').length;
-  const degradedCount = components.filter(c => c.status === 'degraded').length;
-  
-  if (unhealthyCount > 0) {
+  const postgres = components.find(c => c.name === 'postgresql');
+  const neo4j = components.find(c => c.name === 'neo4j');
+
+  if (postgres?.status === 'unhealthy') {
     return 'unhealthy';
   }
-  
-  if (degradedCount > 0) {
+
+  if (neo4j?.status === 'unhealthy') {
+    return 'degraded';
+  }
+
+  if (components.some(c => c.status === 'degraded')) {
     return 'degraded';
   }
   
@@ -324,7 +351,35 @@ export async function GET(request: NextRequest): Promise<NextResponse<HealthResp
     timestamp: new Date().toISOString(),
     uptime: process.uptime(),
     version: process.env.npm_package_version || '0.1.0',
+    mode: 'http',
+    interface: 'rest',
   };
+
+  const postgres = componentResults.find(c => c.name === 'postgresql');
+  const neo4jComponent = componentResults.find(c => c.name === 'neo4j');
+
+  if (postgres && neo4jComponent) {
+    healthResponse.dependencies = {
+      postgres: {
+        status: postgres.status === 'healthy' ? 'up' : 'down',
+        required: true,
+        latency_ms: postgres.latency,
+      },
+      neo4j: {
+        status: neo4jComponent.status === 'healthy' ? 'up' : 'down',
+        required: false,
+        latency_ms: neo4jComponent.latency,
+      },
+    };
+
+    if (healthResponse.status === 'degraded' && neo4jComponent.status === 'unhealthy') {
+      healthResponse.degraded = {
+        enabled: true,
+        reason: 'neo4j_unavailable',
+        capabilities_lost: ['semantic_search', 'semantic_read', 'semantic_deprecate'],
+      };
+    }
+  }
   
   // Include components in detailed mode or always for unhealthy status
   if (detailed || healthResponse.status !== 'healthy') {

--- a/src/lib/config/ports.ts
+++ b/src/lib/config/ports.ts
@@ -11,7 +11,7 @@ import { randomInt } from "crypto";
  * Port ranges for different services
  * 
  * - Paperclip (Next.js): 3100-3199
- * - OpenClaw Gateway (MCP): 3200-3299
+ * - Allura MCP HTTP Gateway: 3200-3299
  * - PostgreSQL: 5432 (standard, configurable)
  * - Neo4j HTTP: 7474 (standard, configurable)
  * - Neo4j Bolt: 7687 (standard, configurable)
@@ -20,6 +20,7 @@ import { randomInt } from "crypto";
 export const PORT_RANGES = {
   paperclip: { min: 3100, max: 3199, default: 3100 },
   openclaw: { min: 3200, max: 3299, default: 3200 },
+  mcp_http: { min: 3200, max: 3299, default: 3201 },
   postgres: { min: 5400, max: 5499, default: 5432 },
   neo4j_http: { min: 7470, max: 7479, default: 7474 },
   neo4j_bolt: { min: 7680, max: 7689, default: 7687 },
@@ -82,6 +83,7 @@ export function getPort(
 export interface PortConfig {
   paperclip: number;
   openclaw: number;
+  mcp_http: number;
   postgres: number;
   neo4j_http: number;
   neo4j_bolt: number;
@@ -99,6 +101,9 @@ export function getPortConfig(randomize: boolean = false): PortConfig {
     openclaw: randomize
       ? getRandomPort(PORT_RANGES.openclaw.min, PORT_RANGES.openclaw.max)
       : getPort("openclaw", "OPENCLAW_PORT"),
+    mcp_http: randomize
+      ? getRandomPort(PORT_RANGES.mcp_http.min, PORT_RANGES.mcp_http.max)
+      : getPort("mcp_http", "ALLURA_MCP_HTTP_PORT"),
     postgres: getPort("postgres", "POSTGRES_PORT"),
     neo4j_http: getPort("neo4j_http", "NEO4J_HTTP_PORT"),
     neo4j_bolt: getPort("neo4j_bolt", "NEO4J_BOLT_PORT"),
@@ -112,6 +117,7 @@ export function getPortConfig(randomize: boolean = false): PortConfig {
 export function getServiceUrls(ports?: Partial<PortConfig>): {
   paperclip: string;
   openclaw: string;
+  mcp_http: string;
   postgres: string;
   neo4j_http: string;
   neo4j_bolt: string;
@@ -122,6 +128,7 @@ export function getServiceUrls(ports?: Partial<PortConfig>): {
   return {
     paperclip: `http://localhost:${config.paperclip}`,
     openclaw: `http://localhost:${config.openclaw}`,
+    mcp_http: `http://localhost:${config.mcp_http}`,
     postgres: `postgresql://${process.env.POSTGRES_USER || "ronin4life"}:${process.env.POSTGRES_PASSWORD || "password"}@localhost:${config.postgres}/${process.env.POSTGRES_DB || "memory"}`,
     neo4j_http: `http://localhost:${config.neo4j_http}`,
     neo4j_bolt: `bolt://localhost:${config.neo4j_bolt}`,
@@ -135,6 +142,7 @@ export function getServiceUrls(ports?: Partial<PortConfig>): {
 export const PORT_ENV_VARS = {
   paperclip: "PAPERCLIP_PORT",
   openclaw: "OPENCLAW_PORT",
+  mcp_http: "ALLURA_MCP_HTTP_PORT",
   postgres: "POSTGRES_PORT",
   neo4j_http: "NEO4J_HTTP_PORT",
   neo4j_bolt: "NEO4J_BOLT_PORT",
@@ -153,6 +161,7 @@ export function generateEnvEntries(randomize: boolean = false): string {
 # =============================================================================
 PAPERCLIP_PORT=${config.paperclip}
 OPENCLAW_PORT=${config.openclaw}
+ALLURA_MCP_HTTP_PORT=${config.mcp_http}
 POSTGRES_PORT=${config.postgres}
 NEO4J_HTTP_PORT=${config.neo4j_http}
 NEO4J_BOLT_PORT=${config.neo4j_bolt}
@@ -161,6 +170,7 @@ DOZZLE_PORT=${config.dozzle}
 # Derived URLs
 NEXT_PUBLIC_APP_URL=http://localhost:${config.paperclip}
 OPENCLAW_GATEWAY_URL=http://localhost:${config.openclaw}
+ALLURA_MCP_HTTP_URL=http://localhost:${config.mcp_http}
 `.trim();
 }
 

--- a/src/lib/memory/canonical-contracts.ts
+++ b/src/lib/memory/canonical-contracts.ts
@@ -72,6 +72,15 @@ export type MemoryProvenance = 'conversation' | 'manual';
  */
 export type MemoryStatus = 'active' | 'deprecated';
 
+export interface MemoryResponseMeta {
+  contract_version: 'v1';
+  degraded: boolean;
+  degraded_reason?: 'neo4j_unavailable';
+  stores_used: Array<'postgres' | 'neo4j'>;
+  stores_attempted: Array<'postgres' | 'neo4j'>;
+  warnings?: string[];
+}
+
 // ── Request/Response Contracts ───────────────────────────────────────────
 
 /**
@@ -125,6 +134,9 @@ export interface MemoryAddResponse {
   
   /** Timestamp */
   created_at: string;
+
+  /** Execution metadata */
+  meta?: MemoryResponseMeta;
 }
 
 /**
@@ -186,6 +198,9 @@ export interface MemorySearchResponse {
   
   /** Query execution time (ms) */
   latency_ms: number;
+
+  /** Execution metadata */
+  meta?: MemoryResponseMeta;
 }
 
 /**
@@ -232,6 +247,9 @@ export interface MemoryGetResponse {
   
   /** Usage count */
   usage_count?: number;
+
+  /** Execution metadata */
+  meta?: MemoryResponseMeta;
 }
 
 /**
@@ -266,6 +284,9 @@ export interface MemoryListResponse {
   
   /** Has more results */
   has_more: boolean;
+
+  /** Execution metadata */
+  meta?: MemoryResponseMeta;
 }
 
 /**
@@ -299,6 +320,9 @@ export interface MemoryDeleteResponse {
   
   /** Recovery window (days) */
   recovery_days: number;
+
+  /** Execution metadata */
+  meta?: MemoryResponseMeta;
 }
 
 // ── Governance Contracts (Curator Workflow) ───────────────────────────────

--- a/src/mcp/canonical-http-gateway.ts
+++ b/src/mcp/canonical-http-gateway.ts
@@ -13,7 +13,49 @@ import { config } from "dotenv";
 
 config();
 
-const PORT = process.env.CANONICAL_HTTP_PORT || 3201;
+function resolveHttpPort(): { port: number; source: string; warnings: string[] } {
+  const warnings: string[] = [];
+
+  if (process.env.ALLURA_MCP_HTTP_PORT) {
+    return {
+      port: parseInt(process.env.ALLURA_MCP_HTTP_PORT, 10),
+      source: "ALLURA_MCP_HTTP_PORT",
+      warnings,
+    };
+  }
+
+  if (process.env.CANONICAL_HTTP_PORT) {
+    warnings.push("CANONICAL_HTTP_PORT is deprecated; use ALLURA_MCP_HTTP_PORT");
+    return {
+      port: parseInt(process.env.CANONICAL_HTTP_PORT, 10),
+      source: "CANONICAL_HTTP_PORT",
+      warnings,
+    };
+  }
+
+  if (process.env.OPENCLAW_PORT) {
+    warnings.push("OPENCLAW_PORT is deprecated for canonical MCP HTTP; use ALLURA_MCP_HTTP_PORT");
+    return {
+      port: parseInt(process.env.OPENCLAW_PORT, 10),
+      source: "OPENCLAW_PORT",
+      warnings,
+    };
+  }
+
+  if (process.env.PORT) {
+    warnings.push("PORT is deprecated for canonical MCP HTTP; use ALLURA_MCP_HTTP_PORT");
+    return {
+      port: parseInt(process.env.PORT, 10),
+      source: "PORT",
+      warnings,
+    };
+  }
+
+  return { port: 3201, source: "default", warnings };
+}
+
+const HTTP_PORT = resolveHttpPort();
+const PORT = HTTP_PORT.port;
 
 // Import canonical tools
 import {
@@ -231,10 +273,20 @@ const server = createServer(async (req, res) => {
       const result = await toolHandlers[name](args || {});
       res.writeHead(200, { ...corsHeaders, "Content-Type": "application/json" });
       res.end(JSON.stringify(result));
-    } else if (url.pathname === "/health") {
+    } else if (url.pathname === "/health" || url.pathname === "/api/health") {
       // Health check
       res.writeHead(200, { ...corsHeaders, "Content-Type": "application/json" });
-      res.end(JSON.stringify({ status: "healthy", timestamp: new Date().toISOString() }));
+      res.end(
+        JSON.stringify({
+          status: "healthy",
+          mode: "http",
+          interface: "mcp-http",
+          port: PORT,
+          port_source: HTTP_PORT.source,
+          warnings: HTTP_PORT.warnings,
+          timestamp: new Date().toISOString(),
+        })
+      );
     } else {
       res.writeHead(404, { ...corsHeaders, "Content-Type": "application/json" });
       res.end(JSON.stringify({ error: "Not found" }));
@@ -248,6 +300,10 @@ const server = createServer(async (req, res) => {
 
 server.listen(PORT, () => {
   console.log(`Canonical HTTP Gateway listening on port ${PORT}`);
+  console.log(`Port source: ${HTTP_PORT.source}`);
+  for (const warning of HTTP_PORT.warnings) {
+    console.warn(`[deprecated-port-contract] ${warning}`);
+  }
   console.log("Available tools: memory_add, memory_search, memory_get, memory_list, memory_delete");
 });
 

--- a/src/mcp/canonical-tools.ts
+++ b/src/mcp/canonical-tools.ts
@@ -28,6 +28,7 @@ import type {
   GroupId,
   MemoryId,
   MemoryProvenance,
+  MemoryResponseMeta,
 } from "@/lib/memory/canonical-contracts";
 
 import { Pool } from "pg";
@@ -83,6 +84,23 @@ function toMemoryId(value: string): MemoryId {
 
 function toProvenance(value: string | null | undefined): MemoryProvenance {
   return value === "manual" ? "manual" : "conversation";
+}
+
+function baseMeta(storesUsed: Array<"postgres" | "neo4j">, degraded: boolean = false): MemoryResponseMeta {
+  return {
+    contract_version: "v1",
+    degraded,
+    stores_used: storesUsed,
+    stores_attempted: ["postgres", "neo4j"],
+    warnings: degraded ? ["semantic layer unavailable; returned episodic results only"] : [],
+  };
+}
+
+function degradedMeta(storesUsed: Array<"postgres" | "neo4j">): MemoryResponseMeta {
+  return {
+    ...baseMeta(storesUsed, true),
+    degraded_reason: "neo4j_unavailable",
+  };
 }
 
 // ── Configuration ─────────────────────────────────────────────────────────
@@ -267,6 +285,7 @@ export async function memory_add(request: MemoryAddRequest): Promise<MemoryAddRe
       stored: "episodic",
       score,
       created_at: createdAt,
+      meta: baseMeta(["postgres"]),
     };
   }
   
@@ -275,7 +294,20 @@ export async function memory_add(request: MemoryAddRequest): Promise<MemoryAddRe
     // Auto mode: Promote immediately
     
     // Check for duplicates (only in auto mode)
-    const duplicateId = await checkDuplicate(neo4j, groupId, request.user_id, request.content);
+    let duplicateId: MemoryId | null = null;
+    try {
+      duplicateId = await checkDuplicate(neo4j, groupId, request.user_id, request.content);
+    } catch (error) {
+      console.warn("[degraded] Neo4j duplicate check unavailable in memory_add:", error);
+      return {
+        id: memoryId,
+        stored: "episodic",
+        score,
+        created_at: createdAt,
+        meta: degradedMeta(["postgres"]),
+      };
+    }
+
     if (duplicateId) {
       // Duplicate found: return existing ID
       return {
@@ -283,6 +315,7 @@ export async function memory_add(request: MemoryAddRequest): Promise<MemoryAddRe
         stored: "semantic",
         score,
         created_at: createdAt,
+        meta: baseMeta(["neo4j"]),
       };
     }
     
@@ -338,6 +371,15 @@ export async function memory_add(request: MemoryAddRequest): Promise<MemoryAddRe
         score,
         created_at: createdAt,
       };
+    } catch (error) {
+      console.warn("[degraded] Neo4j promotion unavailable in memory_add:", error);
+      return {
+        id: memoryId,
+        stored: "episodic",
+        score,
+        created_at: createdAt,
+        meta: degradedMeta(["postgres"]),
+      };
     } finally {
       await session.close();
     }
@@ -366,6 +408,7 @@ export async function memory_add(request: MemoryAddRequest): Promise<MemoryAddRe
       score,
       pending_review: true,
       created_at: createdAt,
+      meta: baseMeta(["postgres"]),
     };
   }
 }
@@ -378,7 +421,7 @@ export async function memory_add(request: MemoryAddRequest): Promise<MemoryAddRe
  * Results merged by relevance score.
  */
 export async function memory_search(request: MemorySearchRequest): Promise<MemorySearchResponse> {
-  const { pg, neo4j } = await getConnections();
+  const { pg, neo4j: neo4jDriver } = await getConnections();
   const startTime = Date.now();
   
    // Validate
@@ -386,63 +429,71 @@ export async function memory_search(request: MemorySearchRequest): Promise<Memor
    const limit = Math.floor(request.limit || 10);
   
   // Parallel search both stores
-  const [episodicResults, semanticResults] = await Promise.all([
-    // PostgreSQL full-text search
-    pg.query<EpisodicMemoryRow>(
-      `SELECT metadata->>'memory_id' AS id, metadata->>'content' AS content, 
-              metadata->>'source' AS provenance,
-              created_at
-        FROM events
-       WHERE group_id = $1
-         AND event_type = 'memory_add'
-         AND ($2::text IS NULL OR metadata->>'user_id' = $2)
-         AND metadata->>'content' ILIKE '%' || $3 || '%'
-       ORDER BY created_at DESC
-       LIMIT $4`,
-      [groupId, request.user_id || null, request.query, limit]
-    ),
-    
-     // Neo4j semantic search
-     (async () => {
-       const session = neo4j.session();
-       try {
-         const result = await session.run(
-           `CALL db.index.fulltext.queryNodes('memory_search_index', $query)
-            YIELD node AS m, score
-            WHERE m.group_id = $groupId
-              AND NOT (m)<-[:SUPERSEDES]-()
-            RETURN m.id AS id,
-                   m.content AS content,
-                   m.score AS score,
-                   m.provenance AS provenance,
-                   m.created_at AS created_at,
-                   m.usage_count AS usage_count,
-                   score AS relevance
-            ORDER BY relevance DESC, m.score DESC
-            LIMIT $limit`,
-           {
-             query: request.query,
-             groupId,
-             limit,
-           }
-         );
-         
-         console.log(`[DEBUG] Neo4j search result count: ${result.records.length} with limit: ${limit}`);
-         
-         return result.records.map((record) => ({
-           id: record.get("id"),
-           content: record.get("content"),
-           score: record.get("score"),
-           provenance: record.get("provenance"),
-           created_at: record.get("created_at"),
-           usage_count: record.get("usage_count")?.toNumber?.() || 0,
-           relevance: record.get("relevance"),
-         }));
-       } finally {
-         await session.close();
-       }
-     })(),
-  ]);
+  const episodicResults = await pg.query<EpisodicMemoryRow>(
+    `SELECT metadata->>'memory_id' AS id, metadata->>'content' AS content, 
+            metadata->>'source' AS provenance,
+            created_at
+      FROM events
+     WHERE group_id = $1
+       AND event_type = 'memory_add'
+       AND ($2::text IS NULL OR metadata->>'user_id' = $2)
+       AND metadata->>'content' ILIKE '%' || $3 || '%'
+     ORDER BY created_at DESC
+     LIMIT $4`,
+    [groupId, request.user_id || null, request.query, limit]
+  );
+
+  let semanticResults: Array<{
+    id: MemoryId;
+    content: string;
+    score: number;
+    provenance: MemoryProvenance;
+    created_at: string;
+    usage_count: number;
+    relevance: number;
+  }> = [];
+  let searchMeta = baseMeta(["postgres", "neo4j"]);
+
+  try {
+      const session = neo4jDriver.session();
+    try {
+      const result = await session.run(
+        `CALL db.index.fulltext.queryNodes('memory_search_index', $query)
+         YIELD node AS m, score
+         WHERE m.group_id = $groupId
+           AND NOT (m)<-[:SUPERSEDES]-()
+         RETURN m.id AS id,
+                m.content AS content,
+                m.score AS score,
+                m.provenance AS provenance,
+                m.created_at AS created_at,
+                m.usage_count AS usage_count,
+                score AS relevance
+         ORDER BY relevance DESC, m.score DESC
+         LIMIT $limit`,
+        {
+          query: request.query,
+          groupId,
+          limit: neo4j.int(limit),
+        }
+      );
+
+      semanticResults = result.records.map((record) => ({
+        id: record.get("id") as MemoryId,
+        content: record.get("content"),
+        score: record.get("score"),
+        provenance: toProvenance(record.get("provenance")),
+        created_at: record.get("created_at"),
+        usage_count: record.get("usage_count")?.toNumber?.() || 0,
+        relevance: record.get("relevance"),
+      }));
+    } finally {
+      await session.close();
+    }
+  } catch (error) {
+    console.warn("[degraded] Neo4j unavailable in memory_search:", error);
+    searchMeta = degradedMeta(["postgres"]);
+  }
   
   // Merge results
   const episodic = episodicResults.rows.map((row) => ({
@@ -476,6 +527,7 @@ export async function memory_search(request: MemorySearchRequest): Promise<Memor
     results,
     count: results.length,
     latency_ms: latency,
+    meta: searchMeta,
   };
 }
 
@@ -492,6 +544,7 @@ export async function memory_get(request: MemoryGetRequest): Promise<MemoryGetRe
   const groupId = validateGroupId(request.group_id);
   
   // Try Neo4j first (semantic)
+  let getMeta = baseMeta(["postgres", "neo4j"]);
   const session = neo4j.session();
   try {
     const result = await session.run(
@@ -522,8 +575,12 @@ export async function memory_get(request: MemoryGetRequest): Promise<MemoryGetRe
         created_at: record.get("created_at"),
         version: record.get("version")?.toNumber?.() || 1,
         usage_count: 0, // TODO: Track usage
+        meta: getMeta,
       };
     }
+  } catch (error) {
+    console.warn("[degraded] Neo4j unavailable in memory_get:", error);
+    getMeta = degradedMeta(["postgres"]);
   } finally {
     await session.close();
   }
@@ -555,6 +612,7 @@ export async function memory_get(request: MemoryGetRequest): Promise<MemoryGetRe
     user_id: row.user_id || "unknown",
     created_at: row.created_at,
     usage_count: 0,
+    meta: getMeta,
   };
 }
 
@@ -571,9 +629,10 @@ export async function memory_list(request: MemoryListRequest): Promise<MemoryLis
   const offset = request.offset || 0;
   
   try {
-    const { pg, neo4j } = await getConnections();
+    const { pg, neo4j: neo4jDriver } = await getConnections();
     
     // Parallel query both stores
+    let listMeta = baseMeta(["postgres", "neo4j"]);
     const [episodicResults, semanticResults] = await Promise.all([
       // PostgreSQL
       pg.query<EpisodicMemoryRow>(
@@ -595,25 +654,25 @@ export async function memory_list(request: MemoryListRequest): Promise<MemoryLis
       
       // Neo4j
         (async () => {
-          const session = neo4j.session();
+          const session = neo4jDriver.session();
           try {
-            const result = await session.run(
-              `MATCH (m:Memory)
-               WHERE m.group_id = $groupId
-                 AND m.user_id = $userId
-                 AND NOT (m)<-[:SUPERSEDES]-()
-               WITH m.id AS id,
-                    m.content AS content,
-                    m.score AS score,
-                    m.provenance AS provenance,
-                    m.user_id AS user_id,
-                    m.created_at AS created_at,
-                    m.version AS version
-               RETURN id, content, score, provenance, user_id, created_at, version
+             const result = await session.run(
+               `MATCH (m:Memory)
+                WHERE m.group_id = $groupId
+                  AND m.user_id = $userId
+                  AND NOT (m)<-[:SUPERSEDES]-()
+               RETURN m.id AS id,
+                      m.content AS content,
+                      m.score AS score,
+                      m.provenance AS provenance,
+                      m.user_id AS user_id,
+                      m.created_at AS created_at,
+                      m.version AS version
                ORDER BY created_at DESC
-               LIMIT $limit OFFSET $offset`,
-              { groupId, userId: request.user_id, limit, offset }
-            );
+               SKIP $offset
+               LIMIT $limit`,
+               { groupId, userId: request.user_id, limit: neo4j.int(limit), offset: neo4j.int(offset) }
+             );
             
             return result.records.map((record) => ({
               id: record.get("id") as MemoryId,
@@ -626,9 +685,10 @@ export async function memory_list(request: MemoryListRequest): Promise<MemoryLis
               version: record.get("version")?.toNumber?.() || 1,
               usage_count: 0,
             }));
-          } catch (err) {
-            console.error("Neo4j query error in memory_list:", err);
-            return [];
+           } catch (err) {
+             console.warn("[degraded] Neo4j query error in memory_list:", err);
+             listMeta = degradedMeta(["postgres"]);
+             return [];
           } finally {
             await session.close();
           }
@@ -651,11 +711,12 @@ export async function memory_list(request: MemoryListRequest): Promise<MemoryLis
     .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
     .slice(0, limit);
   
-  return {
-    memories,
-    total: memories.length,
-    has_more: episodicResults.rows?.length === limit || semanticResults.length === limit,
-  };
+   return {
+     memories,
+     total: memories.length,
+     has_more: episodicResults.rows?.length === limit || semanticResults.length === limit,
+     meta: listMeta,
+   };
   } catch (error) {
     console.error("memory_list error:", error);
     throw error;
@@ -696,6 +757,7 @@ export async function memory_delete(request: MemoryDeleteRequest): Promise<Memor
   );
   
   // 2. Mark Neo4j node as deprecated (if exists)
+  let deleteMeta = baseMeta(["postgres", "neo4j"]);
   const session = neo4j.session();
   try {
     await session.run(
@@ -707,6 +769,9 @@ export async function memory_delete(request: MemoryDeleteRequest): Promise<Memor
        RETURN m.id AS id`,
       { id: request.id, groupId, deletedAt }
     );
+  } catch (error) {
+    console.warn("[degraded] Neo4j unavailable in memory_delete:", error);
+    deleteMeta = degradedMeta(["postgres"]);
   } finally {
     await session.close();
   }
@@ -716,6 +781,7 @@ export async function memory_delete(request: MemoryDeleteRequest): Promise<Memor
     deleted: true,
     deleted_at: deletedAt,
     recovery_days: RECOVERY_WINDOW_DAYS,
+    meta: deleteMeta,
   };
 }
 


### PR DESCRIPTION
## Summary
- align canonical MCP runtime and HTTP adapter contracts around one primary port variable and truthful health semantics
- surface Neo4j degradation explicitly in health and canonical memory responses instead of silently swallowing semantic failures
- make canonical memory regression tests rerun-safe and verify them with three consecutive passes

## Change slices
- `04b74f2c` — runtime/port/healthcheck contract
  - normalizes canonical HTTP adapter port handling around `ALLURA_MCP_HTTP_PORT`
  - keeps deprecated aliases for compatibility
  - aligns stdio MCP container healthchecks to process-based liveness
  - adds HTTP adapter health metadata and `/api/health` compatibility alias
- `89fe43f9` — degraded-mode semantics + test stability
  - adds explicit degraded metadata to canonical memory responses
  - marks health as `degraded` when PostgreSQL is up and Neo4j is down
  - stabilizes canonical-memory tests with per-run tenant isolation and unique content
  - documents the runtime rule: PostgreSQL required, Neo4j degradable

## Verification evidence
- canonical-memory suite passed 3 consecutive runs:
  - `bun vitest run src/__tests__/canonical-memory.test.ts`
  - `bun vitest run src/__tests__/canonical-memory.test.ts`
  - `bun vitest run src/__tests__/canonical-memory.test.ts`
- degraded health verified with Neo4j unavailable:
  - `NEO4J_URI=bolt://127.0.0.1:1 ... /api/health?detailed=true`
  - response included `status: \"degraded\"`, `dependencies.neo4j.status: \"down\"`, and `degraded.reason: \"neo4j_unavailable\"`
- degraded canonical tool behavior verified with Neo4j unavailable:
  - `memory_search.meta.degraded === true`
  - `memory_list.meta.degraded === true`
  - `stores_used: [\"postgres\"]`

## Rollback boundary
- `v-pre-hardening` should remain the rollback anchor before this branch is merged
- this PR keeps runtime-contract changes separate from degraded-mode semantics to simplify rollback and review

## Notes
- local generated files (`node_modules/.vite/vitest/results.json`, `tsconfig.tsbuildinfo`) remain uncommitted and are not part of this PR
- one optional follow-up remains: add a final degraded-mode regression for `memory_add` auto-promotion fallback