### PR TITLE
fix: clarify primary docker-compose.yml + add DOCKER.md (Issue #11)

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,31 @@
+# Docker Compose File Guide
+
+This repo contains multiple docker-compose files. Here is their status:
+
+| File | Status | Purpose |
+|------|--------|---------|
+| `docker-compose.yml` (root) | ✅ **PRIMARY** | Local development & production. Use this. |
+| `docker-compose.enterprise.yml` | 🔧 Overlay | Enterprise/multi-tenant add-on. Use with `--file` flag on top of primary. |
+| `docker/docker-compose.yml` | ⚠️ DEPRECATED | Legacy sandbox. Do not use for new work. |
+| `archive/sovereign-memory-mvp/docker-compose.yml` | 📦 Archived | Historical MVP reference only. |
+
+## Quickstart
+
+```bash
+# Full stack (recommended)
+docker compose up
+
+# Enterprise overlay
+docker compose -f docker-compose.yml -f docker-compose.enterprise.yml up
+```
+
+## Services
+
+| Service | Port | Description |
+|---------|------|-------------|
+| `web` | 3100 | Allura Next.js web app |
+| `mcp` | — | MCP memory server |
+| `postgres` | 5432 | Primary relational DB |
+| `neo4j` | 7474 / 7687 | Graph memory layer |
+| `ruvector` | 5433 | Vector DB (RuVector) |
+| `dozzle` | 8088 | Log viewer UI |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,15 @@
+# =============================================================================
+# PRIMARY docker-compose.yml — use this for all local development and production
+# =============================================================================
+# Other compose files in this repo:
+#   docker/docker-compose.yml              — DEPRECATED (legacy sandbox, do not use)
+#   docker-compose.enterprise.yml         — enterprise/multi-tenant overlay only
+#   archive/sovereign-memory-mvp/*        — archived MVP, historical reference only
+#
+# To start the full stack:
+#   docker compose up
+# =============================================================================
+
 services:
   postgres:
     image: postgres:16


### PR DESCRIPTION
## Summary

Resolves the docker-compose config drift flagged by `scout risks`.

## Changes

### 1. `docker-compose.yml` — Primary marker comment
Added a clear header block at the top explaining:
- This is the **only** file to use for local dev and production
- What the other compose files are for (deprecated, overlay, archived)
- Quick `docker compose up` command

### 2. `DOCKER.md` — New doc
Adds a reference table for all compose files in the repo, their status (PRIMARY / DEPRECATED / Archived / Overlay), and a quickstart guide.

## Files Changed
- `docker-compose.yml` — added primary comment header
- `DOCKER.md` — new file

## Testing
- [ ] `docker compose up` still works from root
- [ ] `scout risks` no longer flags config-drift for docker-compose

## Risk
None — no functional changes, documentation only.

Closes #11