### PR TITLE
fix(tokens): remove deprecated Memory Explorer gold

### DIFF
--- a/src/components/memory-explorer/GraphNode.tsx
+++ b/src/components/memory-explorer/GraphNode.tsx
@@ -19,7 +19,7 @@ const NODE_COLOR_VARS: Record<NodeType, { fill: string; stroke: string }> = {
   memory:   { fill: "var(--dashboard-info)",           stroke: "var(--allura-blue)" },
   insight:  { fill: "var(--dashboard-accent)",          stroke: "var(--allura-orange)" },
   evidence: { fill: "var(--dashboard-success)",          stroke: "var(--allura-green)" },
-  agent:    { fill: "var(--allura-gold)",                stroke: "var(--allura-gold)" },
+  agent:    { fill: "var(--tone-gold-bg)",                stroke: "var(--tone-gold-text)" },
   project:  { fill: "var(--allura-charcoal)",            stroke: "var(--allura-charcoal)" },
   system:   { fill: "var(--dashboard-text-secondary)",   stroke: "var(--dashboard-text-muted)" },
 }

--- a/src/components/memory-explorer/memory-explorer.css
+++ b/src/components/memory-explorer/memory-explorer.css
@@ -105,8 +105,8 @@
 }
 
 .memory-explorer__node--agent .node-shape {
-  fill: var(--allura-gold);
-  stroke: var(--allura-gold);
+  fill: var(--tone-gold-bg);
+  stroke: var(--tone-gold-text);
 }
 
 .memory-explorer__node--project .node-shape {
@@ -463,7 +463,8 @@
 }
 
 .memory-explorer__legend-dot--agent {
-  background: var(--allura-gold);
+  background: var(--tone-gold-bg);
+  border: 1px solid var(--tone-gold-text);
 }
 
 .memory-explorer__legend-dot--project {


### PR DESCRIPTION
## Summary
- replaces Memory Explorer agent node direct `--allura-gold` usage with semantic `--tone-gold-bg` / `--tone-gold-text`
- keeps the agent legend visually gold-coded while satisfying the 2.1 Token Audit rule

## Validation
- `bash scripts/token-compliance.sh`
- `bash scripts/brand-audit.sh`
- `bunx eslint src/components/memory-explorer/GraphNode.tsx`
- `bun run typecheck`
- `bun test src/__tests__/token-compliance.test.ts`

## Notes
- Root cause logged to Allura Brain: `3361ad3a-61b9-43f0-996d-a608c029dd40`
- Worktree residue from Ralph/artifact generation was not staged.