### PR TITLE
fix(memory): restore live-data graph parsing

### DIFF
--- a/blocking_list.md
+++ b/blocking_list.md
@@ -1,3 +1,17 @@
 # blocking_list
+
+> Current scope: Allura Memory Phase 0 finish blockers as reconciled on 2026-05-17.
+> Notion remains the canonical status authority; this file is the local execution ledger.
+> Brain receipts are audit traces, not proof of Done.
+
 | id | status | blocker_type | check | evidence | remediation |
 |---|---|---|---|---|---|
+| B01 | DONE | Review gate | IRIS Brand approval / 2.1 Token Audit | PR #28 merged at `0595f78924ef6ba93baa78238e1421ea1047e8a7`; Notion `2.1 Token Audit` moved to Done; Brain receipts `3361ad3a-61b9-43f0-996d-a608c029dd40`, `f5347a2c-84de-4d19-b898-b4e74bf26187`, `2e3d9fe9-10a6-4641-bdda-0a9e057f35ba` | No further action unless Notion is reopened |
+| B02 | DIRECT_GREEN_RALPH_BLOCKED | Multi-role review | Pike + Fowler + Ralph + IRIS `/allura` gate | PR #29 merged at `ae7c11116fba28c4aa493ec74482574b10bf181e`; direct lint/typecheck/tests/browser smoke green; Notion comment `3631d9be-65b3-816b-96aa-001d27b0d322`; Brain receipt `c6ade62b-4f8c-4ddc-bf19-e1704262249e` | Resolve/waive Ralph nested runtime blocker: `bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted` |
+| B03 | OPEN | Decision ambiguity | 3100 target undefined | Downstream cutover/parity cards blocked | Explicit owner decision: MCP gateway, dashboard UI, or superseded |
+| B04 | OPEN | Scope ambiguity | Cash tracker source missing | No canonical Notion source identified | Captain decision: in-scope with source OR out-of-scope |
+| B05 | VALIDATED_PENDING_MERGE | Build gap | Memory Explorer fetch unstable | Notion card `35d1d9be-65b3-81cb-8ad8-c6b903ddd37d`; root cause was unmerged `368c4eb8` regression fix: Neo4j `Record` values parsed as plain objects, causing `created_at` to become `undefined` and throw `Invalid time value`; also needed 127.0.0.1 dev-origin allowance | Patched on `codex/phase0-b05-live-data`; local API/UI validation green; attach PR evidence, merge, then move Notion card to Done |
+| B06 | IN_PROGRESS | Evidence scatter | Notion + artifacts + memory | PR #27/#28/#29 evidence attached, but Phase 0 closure evidence still split across board, Brain, and local artifacts | Keep this ledger plus Notion finish plan synchronized as each blocker closes |
+| B07 | DEFERRED | Scope drift | Board-config discussions | Phase 1 board-config is explicitly blocked until Phase 0 closes | Do not start Phase 1 board config until all Phase 0 rows are closed/waived |
+| B08 | DIRECT_GREEN_RALPH_BLOCKED | Board evidence completeness | `/allura` split work items | `/allura` direct evidence green via PR #29; Ralph evidence blocked by nested bwrap runtime | Attach waiver or rerun Ralph after runtime fix |
+| B09 | OPEN | Validation gap | CARD-2.4-E | Targeted approval audit test and promotion guard call-site proof still required | Run `bun test src/lib/memory/__tests__/approval-audit.test.ts`; attach review evidence |

--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,8 @@ const config: NextConfig = {
   reactStrictMode: true,
   output: "standalone",
 
+  allowedDevOrigins: ["127.0.0.1"],
+
   logging: {
     fetches: {
       fullUrl: true,

--- a/src/lib/graph-adapter/neo4j-adapter.test.ts
+++ b/src/lib/graph-adapter/neo4j-adapter.test.ts
@@ -3,6 +3,12 @@ import { describe, expect, it, vi } from "vitest"
 import { Neo4jGraphAdapter } from "./neo4j-adapter"
 
 describe("Neo4jGraphAdapter", () => {
+  function makeRecord(fields: Record<string, unknown>) {
+    return {
+      get: (key: string) => fields[key],
+    }
+  }
+
   it("filters deprecated memories from full-text search", async () => {
     const close = vi.fn()
     const run = vi.fn().mockResolvedValue({ records: [] })
@@ -23,6 +29,96 @@ describe("Neo4jGraphAdapter", () => {
     const [cypher] = run.mock.calls[0]
     expect(cypher).toContain("coalesce(m.deprecated, false) = false")
     expect(cypher).toContain("NOT (m)<-[:SUPERSEDES]-()")
+    expect(close).toHaveBeenCalledTimes(1)
+  })
+
+  it("maps list records with Neo4j temporal values without throwing", async () => {
+    const close = vi.fn()
+    const run = vi
+      .fn()
+      .mockResolvedValueOnce({ records: [makeRecord({ total: { toNumber: () => 1 } })] })
+      .mockResolvedValueOnce({
+        records: [
+          makeRecord({
+            id: "mem-001",
+            content: "live memory",
+            score: 0.91,
+            provenance: "conversation",
+            user_id: "ronin704",
+            created_at: {
+              year: { low: 2026 },
+              month: { low: 5 },
+              day: { low: 17 },
+              hour: { low: 6 },
+              minute: { low: 45 },
+              second: { low: 30 },
+              nanosecond: { low: 123000000 },
+              toString: () => "2026-05-17T06:45:30.123000000Z",
+            },
+            version: { toNumber: () => 2 },
+            tags: ["live-data"],
+            group_id: "allura-system",
+            schema_version: { toNumber: () => 1 },
+          }),
+        ],
+      })
+    const session = { run, close }
+    const driver = {
+      session: vi.fn(() => session),
+    }
+
+    const adapter = new Neo4jGraphAdapter(driver as never)
+
+    const result = await adapter.listMemories({
+      group_id: "allura-system" as never,
+      user_id: null,
+    })
+
+    expect(result.total).toBe(1)
+    expect(result.memories[0]).toMatchObject({
+      id: "mem-001",
+      content: "live memory",
+      created_at: "2026-05-17T06:45:30.123Z",
+      group_id: "allura-system",
+      version: 2,
+      tags: ["live-data"],
+    })
+    expect(close).toHaveBeenCalledTimes(1)
+  })
+
+  it("uses a safe fallback timestamp for legacy records with missing dates", async () => {
+    const close = vi.fn()
+    const run = vi
+      .fn()
+      .mockResolvedValueOnce({ records: [makeRecord({ total: { toNumber: () => 1 } })] })
+      .mockResolvedValueOnce({
+        records: [
+          makeRecord({
+            id: "mem-legacy",
+            content: "legacy memory",
+            score: 0.7,
+            provenance: "conversation",
+            user_id: null,
+            created_at: undefined,
+            version: { toNumber: () => 1 },
+            tags: [],
+            group_id: "allura-system",
+          }),
+        ],
+      })
+    const session = { run, close }
+    const driver = {
+      session: vi.fn(() => session),
+    }
+
+    const adapter = new Neo4jGraphAdapter(driver as never)
+
+    const result = await adapter.listMemories({
+      group_id: "allura-system" as never,
+      user_id: null,
+    })
+
+    expect(result.memories[0]?.created_at).toBe("1970-01-01T00:00:00.000Z")
     expect(close).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/lib/graph-adapter/neo4j-adapter.ts
+++ b/src/lib/graph-adapter/neo4j-adapter.ts
@@ -18,7 +18,7 @@ import neo4j from "neo4j-driver"
 import type { ConfidenceScore, GroupId, MemoryId, MemoryProvenance } from "@/lib/memory/canonical-contracts"
 import { CURRENT_SCHEMA_VERSION } from "@/lib/schema-version"
 import { resolveAgentName, resolveProjectName } from "./sync-contract-mappings"
-import { GraphAdapterError, GraphAdapterUnavailableError } from "./types"
+import { GraphAdapterError } from "./types"
 import type {
   CanonicalCheckResult,
   CountResult,
@@ -37,37 +37,80 @@ import type {
 
 // ── Helper: Neo4j DateTime → ISO string ──────────────────────────────────────
 
-function neo4jDateToISO(value: unknown): string {
-  if (typeof value === "string") return value
-  if (value && typeof value === "object" && "year" in value) {
-    if (typeof (value as { toString?: () => string }).toString === "function") {
-      const str = (value as { toString: () => string }).toString()
-      const parsed = new Date(str)
-      if (!isNaN(parsed.getTime())) return parsed.toISOString()
-    }
-    const d = value as Record<string, { low: number; high?: number }>
-    const get = (field: string): number => d[field]?.low ?? 0
-    return new Date(
-      Date.UTC(
-        get("year"),
-        get("month") - 1,
-        get("day"),
-        get("hour"),
-        get("minute"),
-        get("second"),
-        Math.floor(get("nanosecond") / 1_000_000)
-      )
-    ).toISOString()
+const UNKNOWN_DATE_ISO = "1970-01-01T00:00:00.000Z"
+
+type Neo4jIntegerLike = { low?: number; high?: number; toNumber?: () => number }
+type Neo4jRecordLike = { get?: (key: string) => unknown }
+
+function toNumber(value: unknown, fallback = 0): number {
+  if (typeof value === "number") return value
+  if (value && typeof value === "object") {
+    const integer = value as Neo4jIntegerLike
+    if (typeof integer.toNumber === "function") return integer.toNumber()
+    if (typeof integer.low === "number") return integer.low
   }
-  return new Date(value as string | number).toISOString()
+  return fallback
+}
+
+function dateToISO(date: Date): string {
+  return Number.isNaN(date.getTime()) ? UNKNOWN_DATE_ISO : date.toISOString()
+}
+
+function neo4jDateToISO(value: unknown): string {
+  if (value == null) return UNKNOWN_DATE_ISO
+  if (value instanceof Date) return dateToISO(value)
+  if (typeof value === "string" || typeof value === "number") return dateToISO(new Date(value))
+
+  if (typeof value === "object") {
+    const temporal = value as { toStandardDate?: () => Date; toString?: () => string }
+
+    if (typeof temporal.toStandardDate === "function") {
+      return dateToISO(temporal.toStandardDate())
+    }
+
+    if ("year" in value) {
+      if (typeof temporal.toString === "function") {
+        const parsed = new Date(temporal.toString())
+        if (!Number.isNaN(parsed.getTime())) return parsed.toISOString()
+      }
+
+      const d = value as Record<string, unknown>
+      return dateToISO(
+        new Date(
+          Date.UTC(
+            toNumber(d.year),
+            toNumber(d.month, 1) - 1,
+            toNumber(d.day, 1),
+            toNumber(d.hour),
+            toNumber(d.minute),
+            toNumber(d.second),
+            Math.floor(toNumber(d.nanosecond) / 1_000_000)
+          )
+        )
+      )
+    }
+  }
+
+  return UNKNOWN_DATE_ISO
+}
+
+function recordValue(record: Record<string, unknown> | Neo4jRecordLike, key: string): unknown {
+  if (typeof (record as Neo4jRecordLike).get === "function") {
+    try {
+      return (record as Neo4jRecordLike).get?.(key)
+    } catch {
+      return undefined
+    }
+  }
+  return (record as Record<string, unknown>)[key]
 }
 
 function toProvenance(value: string | null | undefined): MemoryProvenance {
   return value === "manual" ? "manual" : "conversation"
 }
 
-function recordToNode(record: Record<string, unknown>): GraphMemoryNode {
-  const get = (key: string) => record[key]
+function recordToNode(record: Record<string, unknown> | Neo4jRecordLike): GraphMemoryNode {
+  const get = (key: string) => recordValue(record, key)
   return {
     id: get("id") as MemoryId,
     content: get("content") as string,
@@ -80,7 +123,7 @@ function recordToNode(record: Record<string, unknown>): GraphMemoryNode {
     deprecated: (get("deprecated") as boolean) ?? false,
     deleted_at: get("deleted_at") ? neo4jDateToISO(get("deleted_at")) : null,
     restored_at: get("restored_at") ? neo4jDateToISO(get("restored_at")) : null,
-    group_id: get("group_id") as GroupId,
+    group_id: (get("group_id") as GroupId | undefined) ?? ("allura-system" as GroupId),
     schema_version: (get("schema_version") as { toNumber?: () => number })?.toNumber?.() ?? CURRENT_SCHEMA_VERSION,
   }
 }
@@ -373,12 +416,16 @@ export class Neo4jGraphAdapter implements IGraphAdapter {
                 m.created_at AS created_at,
                 m.version AS version,
                 m.tags AS tags,
+                m.deprecated AS deprecated,
+                m.deleted_at AS deleted_at,
+                m.restored_at AS restored_at,
+                m.group_id AS group_id,
                 m.schema_version AS schema_version
          ORDER BY m.created_at DESC`,
         { groupId: params.group_id, userId: params.user_id ?? null }
       )
 
-      const memories = result.records.map((record) => recordToNode(record as unknown as Record<string, unknown>))
+      const memories = result.records.map((record) => recordToNode(record as unknown as Neo4jRecordLike))
       return { memories, total }
     } catch (error) {
       throw new GraphAdapterError("neo4j", "listMemories", "List memories failed", error instanceof Error ? error : undefined)

--- a/src/lib/observability/sentry.ts
+++ b/src/lib/observability/sentry.ts
@@ -104,9 +104,10 @@ export function initSentry(config?: SentryConfig): void {
   }
 
   try {
-    // Dynamic import to avoid bundling Sentry when not needed
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const Sentry = require("@sentry/nextjs");
+    // Keep require behind eval so Next does not try to bundle this optional
+    // dependency when Sentry is disabled in local/dev environments.
+    const optionalRequire = eval("require") as NodeRequire;
+    const Sentry = optionalRequire("@sentry/nextjs");
 
     Sentry.init({
       dsn: _config.dsn,


### PR DESCRIPTION
## Summary
- Restore safe Neo4j Record + temporal parsing so memory_list no longer degrades with Invalid time value
- Re-add 127.0.0.1 as an allowed dev origin for local live-data browser validation
- Make optional Sentry loading avoid Next bundling warnings when @sentry/nextjs is not installed
- Reconcile blocking_list.md with PR #28/#29 closure and mark B05 validated pending merge

## Validation
- bunx eslint src/lib/observability/sentry.ts src/lib/graph-adapter/neo4j-adapter.ts src/lib/graph-adapter/neo4j-adapter.test.ts next.config.ts
- bun run typecheck
- bun test src/lib/graph-adapter/neo4j-adapter.test.ts src/__tests__/sentry-integration.test.ts src/lib/dashboard/__tests__/allura-route.test.ts src/__tests__/dashboard-schemas.test.ts src/__tests__/graph-route.test.ts
- bun run build (exits 0; pre-existing standalone tracing warnings remain)
- Live API: /api/memory?group_id=allura-system&limit=1 => 200, meta.degraded=false, stores postgres+graph, warnings []
- Live graph: /api/memory/graph?group_id=allura-system => 200, 85 nodes, 150 returned edges, 788 total_edges
- Browser DOM: /memory shows 30 memories and zero empty/fetch-error states; /allura provenance shows Graph nodes 85 and Graph edges 150; no console/page/request failures