### PR TITLE
feat(dashboard): add canonical memory space route

### DIFF
--- a/src/__tests__/graph-route.test.ts
+++ b/src/__tests__/graph-route.test.ts
@@ -39,7 +39,7 @@ describe("Graph API Route Contract (Story 2.8)", () => {
   })
 
   it("should contain header scoping logic for x-allura-group-id", async () => {
-    const routeModule = await import("@/app/api/memory/graph/route")
+    await import("@/app/api/memory/graph/route")
     const routeContent = await readRouteFile()
 
     // Verify header check is present

--- a/src/app/(main)/dashboard/memory-space/page.tsx
+++ b/src/app/(main)/dashboard/memory-space/page.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from "react"
 import ForceGraph2D from "react-force-graph-2d"
 import { toast } from "sonner"
 
+import { getGraphNodeColor, getResolvedColor } from "@/lib/brand/allura"
 import type { GraphEdge, GraphNode } from "@/lib/dashboard/types"
 import { DEFAULT_GROUP_ID } from "@/lib/defaults/scope"
 
@@ -27,17 +28,6 @@ interface MemoryDetail {
   provenance?: "conversation" | "manual"
   user_id?: string
   created_at?: string
-}
-
-const NODE_COLORS: Record<string, string> = {
-  agent: "#6366f1",
-  event: "#f59e0b",
-  outcome: "#22c55e",
-  insight: "#3b82f6",
-  project: "#a855f7",
-  system: "#6b7280",
-  memory: "#ec4899",
-  evidence: "#14b8a6",
 }
 
 function formatScore(score: MemoryDetail["score"]) {
@@ -160,7 +150,7 @@ export default function MemorySpacePage() {
   const nodeCanvasObject = useCallback(
     (node: ForceGraphNode, ctx: CanvasRenderingContext2D, globalScale: number) => {
       const fontSize = 12 / globalScale
-      const color = NODE_COLORS[node.type] ?? "#6b7280"
+      const color = getGraphNodeColor(node.type)
       const isSelected = selectedNode?.id === node.id
       const isHovered = hoveredNode?.id === node.id
       const isDimmed = searchQuery.length > 0 && !node.label.toLowerCase().includes(searchQuery.toLowerCase())
@@ -175,7 +165,7 @@ export default function MemorySpacePage() {
       if (isSelected || isHovered) {
         ctx.beginPath()
         ctx.arc(node.x ?? 0, node.y ?? 0, radius + 3, 0, 2 * Math.PI)
-        ctx.strokeStyle = isSelected ? "#fbbf24" : "#ffffff"
+        ctx.strokeStyle = isSelected ? getResolvedColor("gold") : getResolvedColor("white")
         ctx.lineWidth = 2 / globalScale
         ctx.stroke()
       }
@@ -273,7 +263,7 @@ export default function MemorySpacePage() {
             <div className="space-y-2 text-xs">
               <div className="flex items-center gap-2">
                 <span className="text-slate-400">Type:</span>
-                <span className="rounded px-1.5 py-0.5 font-medium capitalize text-white" style={{ backgroundColor: NODE_COLORS[selectedNode.type] ?? "#6b7280" }}>{selectedNode.type}</span>
+                <span className="rounded px-1.5 py-0.5 font-medium capitalize text-white" style={{ backgroundColor: getGraphNodeColor(selectedNode.type) }}>{selectedNode.type}</span>
               </div>
               {selectedNode.metadata && Object.entries(selectedNode.metadata).map(([key, value]) => (
                 <div key={key} className="flex items-start gap-2">

--- a/src/app/(main)/dashboard/memory-space/page.tsx
+++ b/src/app/(main)/dashboard/memory-space/page.tsx
@@ -1,0 +1,318 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useState } from "react"
+import ForceGraph2D from "react-force-graph-2d"
+import { toast } from "sonner"
+
+import type { GraphEdge, GraphNode } from "@/lib/dashboard/types"
+import { DEFAULT_GROUP_ID } from "@/lib/defaults/scope"
+
+interface ForceGraphNode extends GraphNode {
+  x?: number
+  y?: number
+  vx?: number
+  vy?: number
+}
+
+interface GraphData {
+  nodes: ForceGraphNode[]
+  links: GraphEdge[]
+}
+
+interface MemoryDetail {
+  id: string
+  content?: string
+  score?: number | { low?: number; high?: number }
+  source?: "episodic" | "semantic" | "both"
+  provenance?: "conversation" | "manual"
+  user_id?: string
+  created_at?: string
+}
+
+const NODE_COLORS: Record<string, string> = {
+  agent: "#6366f1",
+  event: "#f59e0b",
+  outcome: "#22c55e",
+  insight: "#3b82f6",
+  project: "#a855f7",
+  system: "#6b7280",
+  memory: "#ec4899",
+  evidence: "#14b8a6",
+}
+
+function formatScore(score: MemoryDetail["score"]) {
+  if (typeof score === "number") return score.toFixed(2)
+  if (score && typeof score.low === "number") return String(score.low)
+  return "—"
+}
+
+export default function MemorySpacePage() {
+  const [graphData, setGraphData] = useState<GraphData>({ nodes: [], links: [] })
+  const [isLoading, setIsLoading] = useState(true)
+  const [graphError, setGraphError] = useState<string | null>(null)
+  const [selectedNode, setSelectedNode] = useState<GraphNode | null>(null)
+  const [searchQuery, setSearchQuery] = useState("")
+  const [activeTypeFilter, setActiveTypeFilter] = useState<string | null>(null)
+  const [hoveredNode, setHoveredNode] = useState<GraphNode | null>(null)
+  const [selectedMemory, setSelectedMemory] = useState<MemoryDetail | null>(null)
+  const [isDetailLoading, setIsDetailLoading] = useState(false)
+  const [detailError, setDetailError] = useState<string | null>(null)
+
+  const clearSelection = useCallback(() => {
+    setSelectedNode(null)
+    setSelectedMemory(null)
+    setDetailError(null)
+  }, [])
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function load() {
+      setIsLoading(true)
+      setGraphError(null)
+
+      try {
+        const response = await fetch(`/api/memory/graph?group_id=${encodeURIComponent(DEFAULT_GROUP_ID)}`)
+        const data = await response.json()
+
+        if (!response.ok) {
+          throw new Error(data?.error ?? `HTTP ${response.status}`)
+        }
+
+        if (!cancelled) {
+          setGraphData({ nodes: data.nodes ?? [], links: data.edges ?? [] })
+          if (data.degraded) toast.warning("Memory graph is running in degraded mode.")
+        }
+      } catch (error) {
+        console.error("[MemorySpace] Failed to load graph:", error)
+        if (!cancelled) {
+          setGraphError(error instanceof Error ? error.message : "Failed to load memory graph")
+          setGraphData({ nodes: [], links: [] })
+          toast.error("Failed to load memory graph. Showing empty state.")
+        }
+      } finally {
+        if (!cancelled) setIsLoading(false)
+      }
+    }
+
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function loadDetail(node: GraphNode | null) {
+      if (!node) {
+        setSelectedMemory(null)
+        setDetailError(null)
+        return
+      }
+
+      setIsDetailLoading(true)
+      setDetailError(null)
+
+      try {
+        const response = await fetch(`/api/memory/${encodeURIComponent(node.id)}?group_id=${encodeURIComponent(DEFAULT_GROUP_ID)}`)
+        const data = await response.json()
+
+        if (!response.ok) throw new Error(data?.error ?? `HTTP ${response.status}`)
+        if (!cancelled) setSelectedMemory(data)
+      } catch (error) {
+        console.error("[MemorySpace] Failed to load memory detail:", error)
+        if (!cancelled) {
+          setDetailError("Could not load memory detail.")
+          setSelectedMemory(null)
+        }
+      } finally {
+        if (!cancelled) setIsDetailLoading(false)
+      }
+    }
+
+    void loadDetail(selectedNode)
+    return () => {
+      cancelled = true
+    }
+  }, [selectedNode])
+
+  const filteredData = useMemo(() => {
+    let nodes = graphData.nodes
+
+    if (searchQuery) {
+      const query = searchQuery.toLowerCase()
+      nodes = nodes.filter(
+        (node) => node.label.toLowerCase().includes(query) || String(node.metadata?.description ?? "").toLowerCase().includes(query)
+      )
+    }
+
+    if (activeTypeFilter) nodes = nodes.filter((node) => node.type === activeTypeFilter)
+
+    const nodeIds = new Set(nodes.map((node) => node.id))
+    const links = graphData.links.filter((edge) => nodeIds.has(edge.source) && nodeIds.has(edge.target))
+
+    return { nodes, links }
+  }, [graphData, searchQuery, activeTypeFilter])
+
+  const nodeTypes = useMemo(() => Array.from(new Set(graphData.nodes.map((node) => node.type))), [graphData.nodes])
+
+  const nodeCanvasObject = useCallback(
+    (node: ForceGraphNode, ctx: CanvasRenderingContext2D, globalScale: number) => {
+      const fontSize = 12 / globalScale
+      const color = NODE_COLORS[node.type] ?? "#6b7280"
+      const isSelected = selectedNode?.id === node.id
+      const isHovered = hoveredNode?.id === node.id
+      const isDimmed = searchQuery.length > 0 && !node.label.toLowerCase().includes(searchQuery.toLowerCase())
+      const radius = isSelected ? 8 : isHovered ? 7 : 5
+      const alpha = isDimmed ? 0.25 : 1
+
+      ctx.beginPath()
+      ctx.arc(node.x ?? 0, node.y ?? 0, radius, 0, 2 * Math.PI)
+      ctx.fillStyle = color + Math.round(alpha * 255).toString(16).padStart(2, "0")
+      ctx.fill()
+
+      if (isSelected || isHovered) {
+        ctx.beginPath()
+        ctx.arc(node.x ?? 0, node.y ?? 0, radius + 3, 0, 2 * Math.PI)
+        ctx.strokeStyle = isSelected ? "#fbbf24" : "#ffffff"
+        ctx.lineWidth = 2 / globalScale
+        ctx.stroke()
+      }
+
+      if (globalScale > 0.8 || isSelected || isHovered) {
+        ctx.font = `${fontSize}px sans-serif`
+        ctx.fillStyle = `rgba(255, 255, 255, ${alpha})`
+        ctx.textAlign = "center"
+        ctx.fillText(node.label, node.x ?? 0, (node.y ?? 0) + radius + fontSize + 2)
+      }
+    },
+    [hoveredNode, searchQuery, selectedNode]
+  )
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-[var(--dashboard-text-muted)]">Memory Space</p>
+          <h1 className="text-2xl font-semibold text-[var(--dashboard-text-primary)]">Governed memory graph</h1>
+          <p className="mt-1 max-w-2xl text-sm text-[var(--dashboard-text-muted)]">
+            Explore Allura&apos;s scoped memory graph, inspect node details, and preserve tenant context on every action.
+          </p>
+        </div>
+        <div className="rounded-full border border-[var(--dashboard-border)] bg-[var(--dashboard-surface)] px-3 py-1 text-xs font-semibold text-[var(--dashboard-text-secondary)]">
+          Scope: {DEFAULT_GROUP_ID}
+        </div>
+      </div>
+
+      <div className="relative min-h-[640px] overflow-hidden rounded-2xl border border-[var(--dashboard-border)] bg-slate-950 shadow-[var(--allura-sh-md)]">
+        {isLoading ? (
+          <div className="flex h-[640px] items-center justify-center text-sm text-slate-300">Loading memory graph…</div>
+        ) : graphError ? (
+          <div className="flex h-[640px] flex-col items-center justify-center gap-2 px-6 text-center text-sm text-slate-300">
+            <p className="text-base font-semibold text-white">Memory graph unavailable</p>
+            <p className="max-w-lg text-slate-400">{graphError}</p>
+          </div>
+        ) : filteredData.nodes.length === 0 ? (
+          <div className="flex h-[640px] flex-col items-center justify-center gap-2 px-6 text-center text-sm text-slate-300">
+            <p className="text-base font-semibold text-white">No memories match this view</p>
+            <p className="max-w-lg text-slate-400">Clear search or filters, or verify Neo4j has scoped graph data.</p>
+          </div>
+        ) : (
+          <ForceGraph2D
+            graphData={filteredData}
+            nodeCanvasObject={nodeCanvasObject as unknown as (node: object, ctx: CanvasRenderingContext2D, globalScale: number) => void}
+            onNodeClick={setSelectedNode as unknown as (node: object) => void}
+            onBackgroundClick={clearSelection}
+            onNodeHover={setHoveredNode as unknown as (node: object | null) => void}
+            backgroundColor="#0f172a"
+            linkColor={() => "rgba(148, 163, 184, 0.3)"}
+            linkWidth={1}
+            nodeRelSize={6}
+            warmupTicks={100}
+            cooldownTicks={50}
+            d3AlphaDecay={0.02}
+            d3VelocityDecay={0.3}
+          />
+        )}
+
+        <div className="absolute left-4 top-4 z-20 flex max-w-md flex-col gap-2">
+          <div className="rounded-lg border border-slate-700 bg-slate-900/90 p-3 shadow-lg backdrop-blur">
+            <input
+              type="text"
+              placeholder="Search graph nodes…"
+              value={searchQuery}
+              onChange={(event) => setSearchQuery(event.target.value)}
+              className="w-full rounded-md border border-slate-700 bg-transparent px-3 py-1.5 text-sm text-white placeholder:text-slate-400 focus:outline-none focus:ring-1 focus:ring-amber-300"
+            />
+          </div>
+
+          {nodeTypes.length > 0 && (
+            <div className="flex flex-wrap gap-1.5">
+              <button type="button" onClick={() => setActiveTypeFilter(null)} className={`rounded-full px-2.5 py-1 text-xs font-medium transition-colors ${activeTypeFilter === null ? "bg-amber-300 text-slate-950" : "bg-slate-900/80 text-slate-300 hover:bg-slate-800"}`}>
+                All
+              </button>
+              {nodeTypes.map((type) => (
+                <button type="button" key={type} onClick={() => setActiveTypeFilter(type === activeTypeFilter ? null : type)} className={`rounded-full px-2.5 py-1 text-xs font-medium capitalize transition-colors ${activeTypeFilter === type ? "bg-amber-300 text-slate-950" : "bg-slate-900/80 text-slate-300 hover:bg-slate-800"}`}>
+                  {type}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {selectedNode && (
+          <aside className="absolute right-4 top-4 z-20 w-80 rounded-lg border border-slate-700 bg-slate-900/95 p-4 shadow-xl backdrop-blur">
+            <div className="mb-3 flex items-center justify-between gap-3">
+              <h2 className="text-sm font-semibold text-white">{selectedNode.label}</h2>
+              <button type="button" onClick={clearSelection} className="rounded p-1 text-slate-400 hover:bg-slate-800 hover:text-white" aria-label="Close detail panel">
+                ✕
+              </button>
+            </div>
+
+            <div className="space-y-2 text-xs">
+              <div className="flex items-center gap-2">
+                <span className="text-slate-400">Type:</span>
+                <span className="rounded px-1.5 py-0.5 font-medium capitalize text-white" style={{ backgroundColor: NODE_COLORS[selectedNode.type] ?? "#6b7280" }}>{selectedNode.type}</span>
+              </div>
+              {selectedNode.metadata && Object.entries(selectedNode.metadata).map(([key, value]) => (
+                <div key={key} className="flex items-start gap-2">
+                  <span className="shrink-0 text-slate-400">{key}:</span>
+                  <span className="break-all text-slate-300">{typeof value === "string" ? value : JSON.stringify(value)}</span>
+                </div>
+              ))}
+            </div>
+
+            <div className="mt-4 flex gap-2">
+              <a href={`/memory/${selectedNode.id}?group_id=${encodeURIComponent(DEFAULT_GROUP_ID)}`} className="flex-1 rounded-md bg-amber-300 px-3 py-1.5 text-center text-xs font-medium text-slate-950 hover:bg-amber-200">Open Detail</a>
+              <button type="button" onClick={() => { void navigator.clipboard.writeText(selectedNode.id); toast.success("Copied memory ID") }} className="rounded-md border border-slate-700 px-3 py-1.5 text-xs text-slate-300 hover:bg-slate-800">Copy ID</button>
+            </div>
+
+            {isDetailLoading && <p className="mt-3 text-xs text-slate-400">Loading details…</p>}
+            {detailError && <p className="mt-3 text-xs text-red-300">{detailError}</p>}
+
+            {selectedMemory && !isDetailLoading && !detailError && (
+              <div className="mt-4 space-y-2 border-t border-slate-700 pt-3 text-xs text-slate-300">
+                <div>
+                  <p className="font-medium text-white">Content</p>
+                  <p className="mt-1 max-h-28 overflow-auto whitespace-pre-wrap break-words rounded border border-slate-700 bg-slate-950/70 p-2 text-[11px]">{selectedMemory.content ?? "No content returned."}</p>
+                </div>
+                <div className="grid grid-cols-2 gap-x-2 gap-y-1">
+                  <span className="text-slate-400">Score:</span><span>{formatScore(selectedMemory.score)}</span>
+                  <span className="text-slate-400">Source:</span><span className="capitalize">{selectedMemory.source ?? "—"}</span>
+                  <span className="text-slate-400">Provenance:</span><span className="capitalize">{selectedMemory.provenance ?? "—"}</span>
+                  <span className="text-slate-400">Owner:</span><span>{selectedMemory.user_id ?? "—"}</span>
+                  <span className="text-slate-400">Created:</span><span>{selectedMemory.created_at ?? "—"}</span>
+                </div>
+              </div>
+            )}
+          </aside>
+        )}
+
+        <div className="absolute bottom-4 left-4 z-20 rounded-md border border-slate-700 bg-slate-900/80 px-3 py-2 text-xs text-slate-400 backdrop-blur">
+          {filteredData.nodes.length} nodes · {filteredData.links.length} edges{searchQuery && ` · filtered by "${searchQuery}"`}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/(main)/dashboard/page.tsx
+++ b/src/app/(main)/dashboard/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation"
 
 export default function DashboardPage() {
-  redirect("/dashboard/feed")
+  redirect("/dashboard/memory-space")
 }

--- a/src/app/api/permission-profiles/[id]/route.ts
+++ b/src/app/api/permission-profiles/[id]/route.ts
@@ -9,15 +9,16 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 
 import {
   forbiddenResponse,
+  type PermissionProfile,
+  PermissionProfileRequestBodySchema,
   requireRole,
   unauthorizedResponse,
   updatePermissionProfile,
-  PermissionProfileRequestBodySchema,
   validatePermissionProfile,
-  type PermissionProfile,
 } from "@/lib/auth";
 import type { DashboardResult, DashboardWarning } from "@/lib/dashboard/types";
 
@@ -126,8 +127,10 @@ export async function GET(
   if (!profile) {
     return response(null, `Profile not found: ${id}`, [
       {
+        id: "not-found",
         code: "not-found",
         message: `No permission profile exists with id=${id}`,
+        source: SOURCE,
         severity: "info",
       },
     ], 404);
@@ -138,8 +141,10 @@ export async function GET(
   if (!validation.ok) {
     return response(null, `Permission profile contract validation failed: ${validation.errors.join("; ")}`, [
       {
+        id: "shape-drift",
         code: "shape-drift",
         message: validation.errors.join("; "),
+        source: SOURCE,
         severity: "critical",
       },
     ], 500);
@@ -163,8 +168,10 @@ export async function PATCH(
   if (!existingProfile) {
     return response(null, `Profile not found: ${id}`, [
       {
+        id: "not-found",
         code: "not-found",
         message: `No permission profile exists with id=${id}`,
+        source: SOURCE,
         severity: "info",
       },
     ], 404);
@@ -187,11 +194,13 @@ export async function PATCH(
     const parsed = PermissionProfileRequestBodySchema.safeParse(body);
 
     if (!parsed.success) {
-      const message = parsed.error.issues.map((issue) => `${issue.path.join(".")}: ${issue.message}`).join("; ");
+      const message = parsed.error.issues.map((issue: z.ZodIssue) => `${issue.path.join(".")}: ${issue.message}`).join("; ");
       return response(null, `Permission profile validation failed: ${message}`, [
         {
+          id: "validation-error",
           code: "validation-error",
           message,
+          source: SOURCE,
           severity: "critical",
         },
       ], 400);
@@ -213,8 +222,10 @@ export async function PATCH(
     if (!validation.ok) {
       return response(null, `Permission profile contract validation failed: ${validation.errors.join("; ")}`, [
         {
+          id: "shape-drift",
           code: "shape-drift",
           message: validation.errors.join("; "),
+          source: SOURCE,
           severity: "critical",
         },
       ], 500);
@@ -226,16 +237,20 @@ export async function PATCH(
 
     return response(validation.data, null, [
       {
+        id: "audit-persistence-pending",
         code: "audit-persistence-pending",
         message: "PermissionProfile updated; durable persistence/audit wiring remains required before production use.",
+        source: SOURCE,
         severity: "info",
       },
     ], 200);
   } catch (error) {
     return response(null, error instanceof Error ? error.message : "Unknown server error", [
       {
+        id: "internal-error",
         code: "internal-error",
         message: "Permission profile update encountered an error",
+        source: SOURCE,
         severity: "critical",
       },
     ], 500);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,2 @@
 import { redirect } from "next/navigation"
-export default function RootPage() { redirect("/dashboard/feed") }
-
+export default function RootPage() { redirect("/dashboard/memory-space") }

--- a/src/hooks/use-route-state.ts
+++ b/src/hooks/use-route-state.ts
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect, useCallback } from "react"
+import { useCallback, useEffect, useState } from "react"
 import type { DashboardResult } from "@/lib/dashboard/types"
 
 export type RouteStateClassification = "loading" | "success" | "empty" | "error" | "degraded"
@@ -23,6 +23,50 @@ export type RouteStateOptions = {
   emptyThreshold?: number
 }
 
+function classifyRouteState<T>(
+  result: DashboardResult<T> | null,
+  options: RouteStateOptions = {}
+): ClassifiedRouteState<T> {
+  const emptyThreshold = options.emptyThreshold ?? 0
+
+  let state: RouteStateClassification = "success"
+  if (result === null) state = "loading"
+  else if (result.error !== null) state = "error"
+  else if (result.degraded) state = "degraded"
+  else if (result.data === null || (Array.isArray(result.data) && result.data.length <= emptyThreshold)) state = "empty"
+
+  const warnings = result?.warnings ?? []
+  const normalizedWarnings = warnings.map((warning) => {
+    if (warning.code !== undefined) {
+      return {
+        code: warning.code,
+        message: warning.message,
+        source: warning.source,
+        severity: warning.severity ?? "info",
+      }
+    }
+
+    return {
+      code: warning.id || "LEGACY",
+      message: warning.message || "Unknown",
+      source: warning.source,
+      severity: warning.severity ?? "info",
+    }
+  })
+
+  return {
+    data: result?.data ?? null,
+    error: result?.error ?? null,
+    degraded: result?.degraded ?? false,
+    warnings: normalizedWarnings,
+    source: result?.source ?? null,
+    fetchedAt: result?.fetched_at ?? null,
+    isLoading: state === "loading",
+    state,
+    isEmpty: state === "empty",
+  }
+}
+
 /**
  * useRouteStateClassified is a hook that accepts a DashboardResult<T> and
  * provides a consistent state classification across dashboard routes.
@@ -35,55 +79,7 @@ export function useRouteStateClassified<T>(
   result: DashboardResult<T> | null,
   options: RouteStateOptions = {}
 ): ClassifiedRouteState<T> {
-  const emptyThreshold = options.emptyThreshold ?? 0
-
-  // Classify state based on result content
-  const classification = useCallback((): RouteStateClassification => {
-    if (result === null) return "loading"
-    if (result.error !== null) return "error"
-    if (result.degraded) return "degraded"
-    if (result.data === null || (Array.isArray(result.data) && result.data.length <= emptyThreshold)) return "empty"
-    return "success"
-  }, [result, emptyThreshold])
-
-  const state: RouteStateClassification = classification()
-  const isEmpty = state === "empty"
-
-  // Sync fields from DashboardResult
-  const data = result?.data ?? null
-  const error = result?.error ?? null
-  const degraded = result?.degraded ?? false
-  const warnings = result?.warnings ?? []
-  const source = result?.source ?? null
-  const fetchedAt = result?.fetched_at ?? null
-
-  // Map legacy warnings to new shape if needed
-  const normalizedWarnings = warnings.map((w) => {
-    // If already has code field, it's the new shape
-    if ("code" in w && w.code !== undefined) {
-      return w as { code: string; message: string; source?: string; severity: "info" | "warning" | "critical" }
-    }
-    // Legacy shape: convert {id, message, source, severity} to {code, message, source, severity}
-    const legacy = w as unknown as { id?: string; message?: string; source?: string; severity?: string }
-    return {
-      code: legacy.id || "LEGACY",
-      message: legacy.message || "Unknown",
-      source: legacy.source,
-      severity: (legacy.severity || "info") as "info" | "warning" | "critical",
-    }
-  })
-
-  return {
-    data,
-    error,
-    degraded,
-    warnings: normalizedWarnings,
-    source,
-    fetchedAt,
-    isLoading: state === "loading",
-    state,
-    isEmpty,
-  }
+  return classifyRouteState(result, options)
 }
 
 /**
@@ -111,7 +107,7 @@ export function useRouteState<T>(
     try {
       const result = await fetcher()
 
-      const classified = useRouteStateClassified<T>(result, options)
+      const classified = classifyRouteState<T>(result, options)
 
       setState(classified)
     } catch {
@@ -127,7 +123,7 @@ export function useRouteState<T>(
         isEmpty: false,
       })
     }
-  }, [fetcher])
+  }, [fetcher, options])
 
   useEffect(() => {
     fetchData()

--- a/src/navigation/sidebar/sidebar-items.ts
+++ b/src/navigation/sidebar/sidebar-items.ts
@@ -4,9 +4,9 @@ import {
   Brain,
   CheckCircle2,
   Folder,
+  type LucideIcon,
   Settings,
   Users,
-  type LucideIcon,
 } from "lucide-react"
 
 export interface NavSubItem {
@@ -33,7 +33,7 @@ export const sidebarItems: NavGroup[] = [
     id: 1,
     label: "Work",
     items: [
-      { title: "What We Know", url: "/dashboard/feed", icon: Brain },
+      { title: "Memory Space", url: "/dashboard/memory-space", icon: Brain },
       { title: "Decisions", url: "/dashboard/insights", icon: CheckCircle2 },
       { title: "Projects", url: "/dashboard/projects", icon: Folder },
       { title: "Team", url: "/dashboard/agents", icon: Users },


### PR DESCRIPTION
## Summary
- Adds canonical `/dashboard/memory-space` route for the dashboard memory experience.
- Redirects root/dashboard entry points to the memory-space page.
- Updates sidebar, route-state classification, dashboard typing, permission-profile validation, and graph route contract tests.

## Verification
- `/opt/AionUi/resources/bundled-bun/linux-x64/bun test src/__tests__/graph-route.test.ts`
- `/opt/AionUi/resources/bundled-bun/linux-x64/bun run typecheck`
- `/opt/AionUi/resources/bundled-bun/linux-x64/bun x eslint src/__tests__/graph-route.test.ts 'src/app/(main)/dashboard/page.tsx' 'src/app/(main)/dashboard/memory-space/page.tsx' 'src/app/api/permission-profiles/[id]/route.ts' src/app/page.tsx src/hooks/use-route-state.ts src/lib/dashboard/types.ts src/navigation/sidebar/sidebar-items.ts`
- `git diff --check`
- `/opt/AionUi/resources/bundled-bun/linux-x64/bun run build`

## Notes
- Build exits 0 with the known traced-file warning for `.agents/skills/impeccable`.