### PR TITLE
feat(dashboard): DASH-12 lineage + CARD-SHOWCASE-A team page + Story 2.3/2.6 fixes

### DIFF
--- a/src/app/(main)/dashboard/lineage/page.tsx
+++ b/src/app/(main)/dashboard/lineage/page.tsx
@@ -1,0 +1,421 @@
+"use client"
+
+import { format, formatDistanceToNow } from "date-fns"
+import {
+  ArrowRight,
+  Brain,
+  ChevronDown,
+  ChevronRight,
+  Database,
+  GitBranch,
+  Layers,
+  Loader2,
+  RefreshCw,
+  Sparkles,
+} from "lucide-react"
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { DURHAM_GRADIENTS } from "@/lib/brand/durham"
+import { DEFAULT_GROUP_ID } from "@/lib/defaults/scope"
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+interface MemoryTrace {
+  id: string
+  group_id: string
+  type: string
+  content: string
+  agent: string
+  timestamp: string
+  metadata: Record<string, unknown>
+}
+
+interface LineageChain {
+  root: MemoryTrace
+  derived: MemoryTrace[]
+  promotedToSemantic: boolean
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function traceSourceLabel(type: string): string {
+  switch (type.toLowerCase()) {
+    case "memory":
+      return "Episodic Capture"
+    case "decision":
+      return "Decision Record"
+    case "action":
+      return "Agent Action"
+    case "prompt":
+      return "Prompt Trace"
+    default:
+      return type.charAt(0).toUpperCase() + type.slice(1)
+  }
+}
+
+function traceSourceIcon(type: string): React.ReactNode {
+  switch (type.toLowerCase()) {
+    case "memory":
+      return <Brain className="size-4" />
+    case "decision":
+      return <Sparkles className="size-4" />
+    case "action":
+      return <GitBranch className="size-4" />
+    default:
+      return <Database className="size-4" />
+  }
+}
+
+function traceStoreLabel(metadata: Record<string, unknown>): string {
+  if (metadata?.promoted || metadata?.store === "semantic") return "Semantic (Neo4j)"
+  if (metadata?.store === "vector") return "Vector (RuVector)"
+  return "Episodic (PostgreSQL)"
+}
+
+function traceStoreBadgeClass(metadata: Record<string, unknown>): string {
+  if (metadata?.promoted || metadata?.store === "semantic") {
+    return "border-[--durham-status-success-border] bg-[--durham-status-success-bg] text-[--durham-status-success-text]"
+  }
+  if (metadata?.store === "vector") {
+    return "border-[--durham-confidence-border] bg-[--durham-confidence-bg] text-[--durham-confidence-text]"
+  }
+  return "border-[--durham-status-default-border] bg-[--durham-status-default-bg] text-[--durham-status-default-text]"
+}
+
+// ── Build lineage chains from flat trace list ─────────────────────────────────
+// Groups traces by agent+type into logical lineage chains.
+// Each chain shows how a trace type evolved across agent sessions.
+
+function buildLineageChains(traces: MemoryTrace[]): LineageChain[] {
+  if (traces.length === 0) return []
+
+  // Group by agent + type to form chains
+  const groups = new Map<string, MemoryTrace[]>()
+  for (const trace of traces) {
+    const key = `${trace.agent}:${trace.type}`
+    const existing = groups.get(key) ?? []
+    existing.push(trace)
+    groups.set(key, existing)
+  }
+
+  const chains: LineageChain[] = []
+  for (const [, group] of groups) {
+    const sorted = [...group].sort(
+      (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+    )
+    const [root, ...derived] = sorted
+    if (!root) continue
+    const promotedToSemantic = group.some(
+      (t) => t.metadata?.promoted || t.metadata?.store === "semantic"
+    )
+    chains.push({ root, derived, promotedToSemantic })
+  }
+
+  // Sort chains: promoted first, then by root timestamp desc
+  return chains.sort((a, b) => {
+    if (a.promotedToSemantic && !b.promotedToSemantic) return -1
+    if (!a.promotedToSemantic && b.promotedToSemantic) return 1
+    return new Date(b.root.timestamp).getTime() - new Date(a.root.timestamp).getTime()
+  })
+}
+
+// ── Stats bar ─────────────────────────────────────────────────────────────────
+
+interface LineageStats {
+  total: number
+  promoted: number
+  chains: number
+  agents: number
+}
+
+function computeStats(traces: MemoryTrace[], chains: LineageChain[]): LineageStats {
+  return {
+    total: traces.length,
+    promoted: chains.filter((c) => c.promotedToSemantic).length,
+    chains: chains.length,
+    agents: new Set(traces.map((t) => t.agent)).size,
+  }
+}
+
+// ── Chain card ────────────────────────────────────────────────────────────────
+
+function LineageChainCard({ chain }: { chain: LineageChain }) {
+  const [expanded, setExpanded] = useState(false)
+
+  return (
+    <Card className="border-[--durham-border] bg-white/88 shadow-sm">
+      <button
+        type="button"
+        className="w-full p-5 text-left"
+        onClick={() => setExpanded((prev) => !prev)}
+        aria-expanded={expanded}
+      >
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+          <div className="space-y-2">
+            {/* Type + promotion badge row */}
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="flex items-center gap-1.5 text-sm font-medium text-[--durham-rich-navy]">
+                {traceSourceIcon(chain.root.type)}
+                {traceSourceLabel(chain.root.type)}
+              </span>
+              <Badge
+                variant="outline"
+                className={traceStoreBadgeClass(
+                  chain.promotedToSemantic ? { promoted: true } : chain.root.metadata
+                )}
+              >
+                {chain.promotedToSemantic ? "Promoted to Semantic" : traceStoreLabel(chain.root.metadata)}
+              </Badge>
+              {chain.derived.length > 0 && (
+                <Badge
+                  variant="outline"
+                  className="border-[--durham-border] bg-white font-normal text-[--durham-muted-text]"
+                >
+                  {chain.derived.length} revision{chain.derived.length === 1 ? "" : "s"}
+                </Badge>
+              )}
+            </div>
+
+            {/* Content preview */}
+            <p className="max-w-2xl text-sm text-[--durham-deep-graphite] leading-5 line-clamp-2">
+              {chain.root.content || "(no content)"}
+            </p>
+
+            {/* Meta row */}
+            <div className="flex flex-wrap gap-4 text-xs text-[--durham-muted-text]">
+              <span>Agent: {chain.root.agent}</span>
+              <span>Origin: {format(new Date(chain.root.timestamp), "PPP p")}</span>
+              <span>{formatDistanceToNow(new Date(chain.root.timestamp), { addSuffix: true })}</span>
+            </div>
+          </div>
+
+          {/* Expand toggle */}
+          <div className="flex items-center gap-2 text-sm font-medium text-[--durham-rich-navy]">
+            {chain.derived.length > 0 ? (
+              <>
+                <span>{expanded ? "Hide lineage" : "Show lineage"}</span>
+                {expanded ? <ChevronDown className="size-4" /> : <ChevronRight className="size-4" />}
+              </>
+            ) : (
+              <span className="text-[--durham-muted-text] text-xs">No revisions</span>
+            )}
+          </div>
+        </div>
+      </button>
+
+      {/* Expanded lineage chain */}
+      {expanded && chain.derived.length > 0 && (
+        <div className="border-t border-[--durham-inner-border] px-5 pb-5 pt-4 space-y-3">
+          <p className="text-xs font-semibold tracking-[0.2em] uppercase text-[--durham-amber-ochre]">
+            Lineage chain
+          </p>
+          <div className="space-y-2">
+            {/* Root node */}
+            <div className="flex items-start gap-3">
+              <div className="mt-1 flex size-6 shrink-0 items-center justify-center rounded-full bg-[--durham-rich-navy] text-white">
+                <span className="text-[10px] font-bold">1</span>
+              </div>
+              <div className="flex-1 rounded-lg border border-[--durham-border] bg-[--durham-panel-subtle] p-3">
+                <p className="text-xs font-medium text-[--durham-deep-graphite]">Origin trace</p>
+                <p className="mt-1 text-xs text-[--durham-muted-text] line-clamp-2">
+                  {chain.root.content || "(no content)"}
+                </p>
+                <p className="mt-1 text-xs text-[--durham-caption-text]">
+                  {format(new Date(chain.root.timestamp), "PPP p")}
+                </p>
+              </div>
+            </div>
+
+            {/* Derived nodes */}
+            {chain.derived.map((trace, index) => (
+              <div key={trace.id} className="flex items-start gap-3">
+                <div className="relative flex flex-col items-center">
+                  <div className="absolute -top-2 h-2 w-px bg-[--durham-border]" />
+                  <div className="flex size-6 shrink-0 items-center justify-center rounded-full bg-[--durham-steel-blue] text-white">
+                    <span className="text-[10px] font-bold">{index + 2}</span>
+                  </div>
+                </div>
+                <div className="flex-1 rounded-lg border border-[--durham-border] bg-[--durham-panel-subtle] p-3">
+                  <div className="flex items-center gap-2">
+                    <ArrowRight className="size-3 text-[--durham-steel-blue]" />
+                    <p className="text-xs font-medium text-[--durham-deep-graphite]">
+                      Revision {index + 1}
+                    </p>
+                    {index === chain.derived.length - 1 && chain.promotedToSemantic && (
+                      <Badge
+                        variant="outline"
+                        className="border-[--durham-status-success-border] bg-[--durham-status-success-bg] text-[--durham-status-success-text] text-[10px] px-1.5 py-0"
+                      >
+                        Promoted
+                      </Badge>
+                    )}
+                  </div>
+                  <p className="mt-1 text-xs text-[--durham-muted-text] line-clamp-2">
+                    {trace.content || "(no content)"}
+                  </p>
+                  <p className="mt-1 text-xs text-[--durham-caption-text]">
+                    {format(new Date(trace.timestamp), "PPP p")}
+                  </p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </Card>
+  )
+}
+
+// ── Page ──────────────────────────────────────────────────────────────────────
+
+export default function MemoryLineagePage() {
+  const [traces, setTraces] = useState<MemoryTrace[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const loadTraces = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetch(
+        `/api/memory/traces?group_id=${encodeURIComponent(DEFAULT_GROUP_ID)}&limit=200`
+      )
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const data = (await res.json()) as { traces?: MemoryTrace[] }
+      setTraces(data.traces ?? [])
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load memory traces")
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void loadTraces()
+  }, [loadTraces])
+
+  const chains = useMemo(() => buildLineageChains(traces), [traces])
+  const stats = useMemo(() => computeStats(traces, chains), [traces, chains])
+
+  return (
+    <div className="min-h-screen" style={{ backgroundImage: DURHAM_GRADIENTS.page }}>
+      <div className="space-y-6 rounded-[28px] border border-white/70 bg-white/74 p-4 shadow-[--durham-shadow-base]/8 shadow-xl backdrop-blur sm:p-6">
+
+        {/* ── Header ── */}
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="max-w-2xl space-y-2">
+            <p className="text-xs font-semibold tracking-[0.28em] text-[--durham-amber-ochre] uppercase">
+              Memory lineage
+            </p>
+            <h1 className="text-3xl font-semibold tracking-tight text-[--durham-deep-graphite]">
+              How knowledge evolves.
+            </h1>
+            <p className="text-sm leading-6 text-[--durham-muted-text]">
+              Trace how raw episodic captures become semantic knowledge. Each chain shows the
+              origin trace, any revisions, and whether it was promoted to the canonical graph.
+            </p>
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={loadTraces}
+            disabled={loading}
+            className="border-[--durham-border-light] bg-white/90 text-[--durham-rich-navy] hover:bg-[--durham-hover-amber-bg]"
+          >
+            <RefreshCw className={`mr-1 size-3 ${loading ? "animate-spin" : ""}`} />
+            Refresh
+          </Button>
+        </div>
+
+        {/* ── Stats row ── */}
+        {!loading && traces.length > 0 && (
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+            {[
+              { label: "Total traces", value: stats.total, icon: <Layers className="size-4" /> },
+              { label: "Lineage chains", value: stats.chains, icon: <GitBranch className="size-4" /> },
+              { label: "Promoted", value: stats.promoted, icon: <Sparkles className="size-4" /> },
+              { label: "Agents tracked", value: stats.agents, icon: <Brain className="size-4" /> },
+            ].map((stat) => (
+              <Card
+                key={stat.label}
+                className="border-[--durham-border] bg-white/85 shadow-sm"
+              >
+                <CardContent className="flex items-center gap-3 p-4">
+                  <span className="text-[--durham-amber-ochre]">{stat.icon}</span>
+                  <div>
+                    <p className="text-lg font-semibold text-[--durham-deep-graphite]">{stat.value}</p>
+                    <p className="text-xs text-[--durham-muted-text]">{stat.label}</p>
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        )}
+
+        {/* ── Legend ── */}
+        <Card className="border-[--durham-border] bg-white/85 shadow-sm">
+          <CardHeader className="pb-2">
+            <CardTitle className="flex items-center gap-2 text-base text-[--durham-deep-graphite]">
+              <GitBranch className="size-4 text-[--durham-amber-ochre]" />
+              Reading the lineage
+            </CardTitle>
+            <CardDescription className="text-[--durham-muted-text]">
+              Each card represents a lineage chain — traces from the same agent and type, ordered by time.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex flex-wrap gap-3 text-xs text-[--durham-secondary-text]">
+            <div className="flex items-center gap-1.5">
+              <span className="inline-block size-2.5 rounded-full bg-[--durham-rich-navy]" />
+              Episodic (raw trace, PostgreSQL)
+            </div>
+            <div className="flex items-center gap-1.5">
+              <span className="inline-block size-2.5 rounded-full bg-[--durham-status-success-text]" />
+              Promoted to semantic (Neo4j canonical graph)
+            </div>
+            <div className="flex items-center gap-1.5">
+              <span className="inline-block size-2.5 rounded-full bg-[--durham-confidence-text]" />
+              Vector-indexed (RuVector hybrid search)
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* ── Error ── */}
+        {error && (
+          <div className="rounded-2xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+            {error}
+          </div>
+        )}
+
+        {/* ── Loading ── */}
+        {loading && (
+          <div className="flex items-center justify-center py-12 text-sm text-[--durham-muted-text]">
+            <Loader2 className="mr-2 size-5 animate-spin" />
+            Loading memory lineage…
+          </div>
+        )}
+
+        {/* ── Empty ── */}
+        {!loading && chains.length === 0 && !error && (
+          <Card className="border-[--durham-border] bg-white/80 p-8 text-center shadow-sm">
+            <GitBranch className="mx-auto mb-3 size-8 text-[--durham-border]" />
+            <p className="text-sm font-medium text-[--durham-deep-graphite]">No lineage chains found</p>
+            <p className="mt-1 text-xs text-[--durham-muted-text]">
+              Traces will appear here once agents begin logging to the episodic store.
+            </p>
+          </Card>
+        )}
+
+        {/* ── Lineage chains ── */}
+        {!loading && chains.length > 0 && (
+          <div className="space-y-3">
+            {chains.map((chain) => (
+              <LineageChainCard key={`${chain.root.agent}:${chain.root.type}:${chain.root.id}`} chain={chain} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/app/(main)/dashboard/settings/page.tsx
+++ b/src/app/(main)/dashboard/settings/page.tsx
@@ -259,9 +259,9 @@ function StatusBadge({ status }: { status: RuleStatus }) {
     pending: {
       label: "Pending",
       style: {
-        backgroundColor: "color-mix(in srgb, var(--allura-gold) 10%, transparent)",
-        color: "var(--allura-gold-text)",
-        borderColor: "color-mix(in srgb, var(--allura-gold) 30%, transparent)",
+        backgroundColor: "var(--tone-gold-bg)",
+        color: "var(--tone-gold-text)",
+        borderColor: "color-mix(in srgb, var(--tone-gold-text) 30%, transparent)",
       },
     },
     "not-checked": {
@@ -285,7 +285,7 @@ function StatusIcon({ status }: { status: RuleStatus }) {
   const colorMap: Record<RuleStatus, string> = {
     compliant: "var(--allura-green)",
     violation: "var(--dashboard-danger)",
-    pending: "var(--allura-gold)",
+    pending: "var(--tone-gold-text)",
     "not-checked": "var(--allura-gray-500)",
   }
   const color = colorMap[status]
@@ -457,7 +457,7 @@ function GovernanceTab() {
     { label: "Total Rules", value: brandRules.length,  icon: Scale,         accent: "var(--allura-gray-500)" },
     { label: "Compliant",   value: counts.compliant,   icon: CheckCircle2,  accent: "var(--allura-green)" },
     { label: "Violations",  value: counts.violation,   icon: XCircle,       accent: "var(--dashboard-danger)" },
-    { label: "Pending",     value: counts.pending,     icon: Clock,         accent: "var(--allura-gold)" },
+    { label: "Pending",     value: counts.pending,     icon: Clock,         accent: "var(--tone-gold-text)" },
   ]
 
   /* Inner tab state for governance detail panels */
@@ -650,9 +650,9 @@ function GovernanceTab() {
                 </TableBody>
               </Table>
             </div>
-            <div className="rounded-lg border p-3 flex items-start gap-2" style={{ borderColor: "color-mix(in srgb, var(--allura-gold) 30%, transparent)", backgroundColor: "color-mix(in srgb, var(--allura-gold) 5%, transparent)" }}>
-              <AlertTriangle className="size-4 shrink-0 mt-0.5" style={{ color: "var(--allura-gold-text)" }} aria-hidden="true" />
-              <p className="text-xs" style={{ color: "var(--allura-gold-text)" }}>
+            <div className="rounded-lg border p-3 flex items-start gap-2" style={{ borderColor: "color-mix(in srgb, var(--tone-gold-text) 30%, transparent)", backgroundColor: "var(--tone-gold-bg)" }}>
+              <AlertTriangle className="size-4 shrink-0 mt-0.5" style={{ color: "var(--tone-gold-text)" }} aria-hidden="true" />
+              <p className="text-xs" style={{ color: "var(--tone-gold-text)" }}>
                 <strong>Critical:</strong> Allura Gold <code className="font-mono">#C89B3C</code> on Cream{" "}
                 <code className="font-mono">#F5F1E6</code> = <strong>2.1:1 — FAILS AA for all text sizes.</strong>{" "}
                 Gold may only be used for decorative borders, icons (with text label), and non-text UI elements.

--- a/src/app/(main)/dashboard/showcase/page.tsx
+++ b/src/app/(main)/dashboard/showcase/page.tsx
@@ -1,0 +1,328 @@
+"use client"
+
+import { Activity, Brain, Code2, GitBranch, Loader2, Search, Server, Settings2, Shield, Zap } from "lucide-react"
+import { useEffect, useState } from "react"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent } from "@/components/ui/card"
+import { DURHAM_GRADIENTS } from "@/lib/brand/durham"
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+interface Agent {
+  id: string
+  name: string
+  model: string
+  description: string
+  skills: string[]
+  eventCount: number
+  lastActive: string | null
+  status: "active" | "idle" | "offline"
+}
+
+// ── Static persona enrichment ─────────────────────────────────────────────────
+// Each Team RAM member gets a persona layer on top of the API data.
+
+const PERSONA_MAP: Record<
+  string,
+  { persona: string; role: string; specialty: string; icon: React.ReactNode; accentColor: string }
+> = {
+  brooks: {
+    persona: "Frederick Brooks",
+    role: "Chief Architect",
+    specialty: "Conceptual integrity, architecture contracts, task routing",
+    icon: <Brain className="size-5" />,
+    accentColor: "#2c3e56",
+  },
+  jobs: {
+    persona: "Steve Jobs",
+    role: "Intent Gate",
+    specialty: "Scope control, acceptance criteria, product clarity",
+    icon: <Zap className="size-5" />,
+    accentColor: "#b8893c",
+  },
+  woz: {
+    persona: "Steve Wozniak",
+    role: "Primary Builder",
+    specialty: "Autonomous implementation, ships working code, clean diffs",
+    icon: <Code2 className="size-5" />,
+    accentColor: "#2a5e3d",
+  },
+  pike: {
+    persona: "Rob Pike",
+    role: "Interface Gate",
+    specialty: "API surface review, concurrency safety, simplicity veto",
+    icon: <Shield className="size-5" />,
+    accentColor: "#4e6e8a",
+  },
+  bellard: {
+    persona: "Fabrice Bellard",
+    role: "Performance Diagnostics",
+    specialty: "Measurement-first, low-level optimization, correctness under constraints",
+    icon: <Zap className="size-5" />,
+    accentColor: "#7a3a3a",
+  },
+  carmack: {
+    persona: "John Carmack",
+    role: "Performance Specialist",
+    specialty: "API design, latency reduction, real-time systems",
+    icon: <Activity className="size-5" />,
+    accentColor: "#6a3a7a",
+  },
+  fowler: {
+    persona: "Martin Fowler",
+    role: "Maintainability Gate",
+    specialty: "Incremental change, refactoring, design drift documentation",
+    icon: <GitBranch className="size-5" />,
+    accentColor: "#4a5e6d",
+  },
+  knuth: {
+    persona: "Donald Knuth",
+    role: "Data Architect",
+    specialty: "PostgreSQL, Neo4j, query optimization, schema correctness",
+    icon: <Server className="size-5" />,
+    accentColor: "#5e4a2a",
+  },
+  hightower: {
+    persona: "Kelsey Hightower",
+    role: "Infrastructure Lead",
+    specialty: "CI/CD, IaC, container orchestration, observability",
+    icon: <Settings2 className="size-5" />,
+    accentColor: "#3a5a4a",
+  },
+  scout: {
+    persona: "Scout",
+    role: "Recon & Discovery",
+    specialty: "Fast codebase search, pattern grep, config discovery",
+    icon: <Search className="size-5" />,
+    accentColor: "#546272",
+  },
+}
+
+// ── Status helpers ─────────────────────────────────────────────────────────────
+
+function statusDotColor(status: Agent["status"]): string {
+  switch (status) {
+    case "active":
+      return "rgb(22, 163, 74)"
+    case "idle":
+      return "rgb(180, 83, 9)"
+    default:
+      return "rgb(107, 114, 128)"
+  }
+}
+
+function statusLabel(status: Agent["status"]): string {
+  switch (status) {
+    case "active":
+      return "Online"
+    case "idle":
+      return "Idle"
+    default:
+      return "Offline"
+  }
+}
+
+function initials(name: string): string {
+  const words = name.trim().split(/\s+/)
+  if (words.length >= 2) return (words[0]![0]! + words[1]![0]!).toUpperCase()
+  return name.slice(0, 2).toUpperCase()
+}
+
+// ── Skeleton ──────────────────────────────────────────────────────────────────
+
+function ShowcaseSkeleton() {
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {Array.from({ length: 6 }, (_, i) => (
+        <div key={i} className="rounded-2xl border border-[--durham-border] bg-white/80 p-6 space-y-4 animate-pulse">
+          <div className="flex items-center gap-4">
+            <div className="h-14 w-14 rounded-xl bg-[--durham-mist]" />
+            <div className="space-y-2 flex-1">
+              <div className="h-4 w-3/4 rounded bg-[--durham-mist]" />
+              <div className="h-3 w-1/2 rounded bg-[--durham-mist]" />
+            </div>
+          </div>
+          <div className="h-3 w-full rounded bg-[--durham-mist]" />
+          <div className="h-3 w-5/6 rounded bg-[--durham-mist]" />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// ── Agent showcase card ────────────────────────────────────────────────────────
+
+function AgentShowcaseCard({ agent }: { agent: Agent }) {
+  const persona = PERSONA_MAP[agent.id.toLowerCase()]
+  const accentColor = persona?.accentColor ?? "#2c3e56"
+
+  return (
+    <Card className="border-[--durham-border] bg-white/88 shadow-sm hover:shadow-md transition-shadow duration-200">
+      <CardContent className="p-6 space-y-4">
+        {/* Header row */}
+        <div className="flex items-start gap-4">
+          {/* Avatar */}
+          <div
+            className="flex h-14 w-14 shrink-0 items-center justify-center rounded-xl text-white shadow-sm"
+            style={{ backgroundColor: accentColor }}
+          >
+            {persona?.icon ?? <Brain className="size-5" />}
+          </div>
+
+          {/* Name + status */}
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center justify-between gap-2">
+              <h3 className="text-base font-semibold text-[--durham-deep-graphite] truncate">
+                {agent.name}
+              </h3>
+              <span className="flex items-center gap-1.5 shrink-0 text-xs text-[--durham-muted-text]">
+                <span
+                  className="h-2 w-2 rounded-full"
+                  style={{ backgroundColor: statusDotColor(agent.status) }}
+                />
+                {statusLabel(agent.status)}
+              </span>
+            </div>
+            {persona && (
+              <p className="text-xs text-[--durham-amber-ochre] font-medium mt-0.5">
+                {persona.persona}
+              </p>
+            )}
+            <p className="text-xs text-[--durham-muted-text] mt-0.5 font-mono truncate">
+              {agent.model}
+            </p>
+          </div>
+        </div>
+
+        {/* Role badge */}
+        {persona && (
+          <div className="flex items-center">
+            <Badge
+              variant="outline"
+              className="border-[--durham-border] bg-[--durham-panel-subtle] text-[--durham-warm-slate] font-medium"
+            >
+              {persona.role}
+            </Badge>
+          </div>
+        )}
+
+        {/* Description / specialty */}
+        <p className="text-sm text-[--durham-secondary-text] leading-5">
+          {persona?.specialty ?? agent.description}
+        </p>
+
+        {/* Skills */}
+        {agent.skills.length > 0 && (
+          <div className="flex flex-wrap gap-1.5">
+            {agent.skills.slice(0, 4).map((skill) => (
+              <span
+                key={skill}
+                className="rounded-md border border-[--durham-border-light] bg-white px-2 py-0.5 text-[10px] text-[--durham-tertiary-text]"
+              >
+                {skill}
+              </span>
+            ))}
+            {agent.skills.length > 4 && (
+              <span className="rounded-md border border-[--durham-border-light] bg-white px-2 py-0.5 text-[10px] text-[--durham-tertiary-text]">
+                +{agent.skills.length - 4} more
+              </span>
+            )}
+          </div>
+        )}
+
+        {/* Activity footer */}
+        <div className="flex items-center justify-between border-t border-[--durham-inner-border] pt-3 text-xs text-[--durham-caption-text]">
+          <span>{agent.eventCount} events logged</span>
+          {agent.lastActive && (
+            <span>
+              Last active {new Date(agent.lastActive).toLocaleDateString()}
+            </span>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+// ── Page ──────────────────────────────────────────────────────────────────────
+
+export default function TeamShowcasePage() {
+  const [agents, setAgents] = useState<Agent[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    fetch("/api/agents")
+      .then((r) => r.json())
+      .then((data: Agent[]) => setAgents(Array.isArray(data) ? data : []))
+      .catch(() => {})
+      .finally(() => setLoading(false))
+  }, [])
+
+  const activeCount = agents.filter((a) => a.status === "active").length
+  const idleCount = agents.filter((a) => a.status === "idle").length
+  const totalEvents = agents.reduce((sum, a) => sum + a.eventCount, 0)
+
+  return (
+    <div className="min-h-screen" style={{ backgroundImage: DURHAM_GRADIENTS.page }}>
+      <div className="space-y-8 rounded-[28px] border border-white/70 bg-white/74 p-4 shadow-[--durham-shadow-base]/8 shadow-xl backdrop-blur sm:p-6">
+
+        {/* ── Hero ── */}
+        <div className="space-y-3">
+          <p className="text-xs font-semibold tracking-[0.28em] text-[--durham-amber-ochre] uppercase">
+            Team RAM
+          </p>
+          <h1 className="text-3xl font-semibold tracking-tight text-[--durham-deep-graphite]">
+            The Allura AI Agent Team.
+          </h1>
+          <p className="max-w-2xl text-sm leading-6 text-[--durham-muted-text]">
+            A surgical team of specialized AI agents, each owning a distinct domain. No committees —
+            one architect, one intent gate, one builder, and nine domain masters. Every story
+            flows through the right hands.
+          </p>
+        </div>
+
+        {/* ── Stats strip ── */}
+        {!loading && agents.length > 0 && (
+          <div className="flex flex-wrap gap-6 border-y border-[--durham-border] py-4 text-sm text-[--durham-secondary-text]">
+            <span>
+              <strong className="text-[--durham-deep-graphite]">{agents.length}</strong> agents
+            </span>
+            <span>
+              <strong className="text-[--durham-deep-graphite]">{activeCount}</strong> online now
+            </span>
+            <span>
+              <strong className="text-[--durham-deep-graphite]">{idleCount}</strong> idle
+            </span>
+            <span>
+              <strong className="text-[--durham-deep-graphite]">{totalEvents.toLocaleString()}</strong> events logged
+            </span>
+          </div>
+        )}
+
+        {/* ── Cards grid ── */}
+        {loading ? (
+          <ShowcaseSkeleton />
+        ) : agents.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-16 text-[--durham-muted-text]">
+            <Brain className="h-8 w-8 mb-3 opacity-30" />
+            <p className="text-sm">No agents found. Check that the agent definition files are present.</p>
+          </div>
+        ) : (
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {agents.map((agent) => (
+              <AgentShowcaseCard key={agent.id} agent={agent} />
+            ))}
+          </div>
+        )}
+
+        {/* ── Footer note ── */}
+        <p className="text-center text-xs text-[--durham-caption-text]">
+          Agent definitions live in{" "}
+          <code className="rounded bg-[--durham-mist] px-1 py-0.5 font-mono">.opencode/agent/</code>.
+          Activity data is pulled from the PostgreSQL events table with{" "}
+          <code className="rounded bg-[--durham-mist] px-1 py-0.5 font-mono">group_id = allura-system</code>.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/hooks/use-memory-list.ts
+++ b/src/hooks/use-memory-list.ts
@@ -149,6 +149,10 @@ export function useMemoryList({
   const PAGE_LIMIT = limit
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const mountedRef = useRef(true)
+  // Story 2.6: prevent duplicate fetch on mount — the view-change effect owns the
+  // initial load; the search-debounce effect must not fire a redundant fetchMemories()
+  // when searchQuery is still empty on first render.
+  const searchInitializedRef = useRef(false)
 
   // Cleanup on unmount
   useEffect(() => {
@@ -246,7 +250,13 @@ export function useMemoryList({
   }, [searchQuery, groupId, userId, allUsers, fetchMemories])
 
   // FIX BUG-004: debounced real-time search — no Enter key required
+  // Story 2.6: skip the first render when query is empty to avoid a duplicate
+  // fetch — the mount/view-change effect below already handles initial data load.
   useEffect(() => {
+    if (!searchInitializedRef.current) {
+      searchInitializedRef.current = true
+      if (!searchQuery.trim()) return // initial load handled by the view-change effect
+    }
     if (debounceRef.current) clearTimeout(debounceRef.current)
     debounceRef.current = setTimeout(() => {
       if (viewStatus !== "active") return // No search in deleted view

--- a/src/navigation/sidebar/sidebar-items.ts
+++ b/src/navigation/sidebar/sidebar-items.ts
@@ -4,9 +4,11 @@ import {
   Brain,
   CheckCircle2,
   Folder,
+  GitBranch,
   Network,
   Scale,
   Settings,
+  Sparkles,
   Users,
   type LucideIcon,
 } from "lucide-react"
@@ -40,6 +42,7 @@ export const sidebarItems: NavGroup[] = [
       { title: "Decisions", url: "/dashboard/insights", icon: CheckCircle2 },
       { title: "Projects", url: "/dashboard/projects", icon: Folder },
       { title: "Team", url: "/dashboard/agents", icon: Users },
+      { title: "Team Showcase", url: "/dashboard/showcase", icon: Sparkles },
     ],
   },
   {
@@ -69,6 +72,7 @@ export const sidebarItems: NavGroup[] = [
           { title: "Settings", url: "/dashboard/settings" },
           { title: "Health", url: "/dashboard/health", icon: Activity },
           { title: "Audit", url: "/dashboard/audit", icon: BookOpen },
+          { title: "Memory Lineage", url: "/dashboard/lineage", icon: GitBranch },
         ],
       },
       {


### PR DESCRIPTION
## Summary

- **DASH-12**: Memory Lineage screen at `/dashboard/lineage` — shows episodic trace chains grouped by agent/type, with SUPERSEDES-style evolution view, 4-stat summary bar, and readable legend
- **CARD-SHOWCASE-A**: Team Showcase at `/dashboard/showcase` — rich agent gallery presenting Team RAM personas (Brooks, Jobs, Woz, Pike, Bellard, Carmack, Fowler, Knuth, Hightower, Scout) with roles, specialties, live status, and event counts
- **Story 2.3**: Replace deprecated `--allura-gold` references in `settings/page.tsx` with semantic `--tone-gold-bg` / `--tone-gold-text` primitives (StatusBadge pending style, StatusIcon pending color, overviewCard pending accent, warning panel)
- **Story 2.6**: Fix duplicate fetch in `useMemoryList` — `searchInitializedRef` skips the initial debounce fire when `searchQuery` is empty; the mount/view-change effect owns the initial data load
- **Nav**: Memory Lineage and Team Showcase added to sidebar navigation

## Test plan

- [ ] `/dashboard/lineage` loads with trace chains; expand button shows origin + revisions
- [ ] `/dashboard/showcase` loads agent cards with personas and live status
- [ ] Settings page pending status uses gold tone tokens (not raw `--allura-gold`)
- [ ] Memory page no longer fires two fetches on mount (single network call to `/api/memory`)
- [ ] `bun run typecheck` passes clean (zero errors)

## Guardrails checklist

- [x] `group_id = allura-system` on all DB operations
- [x] No mutations to PostgreSQL trace rows
- [x] No new files added to `docs/allura/` beyond canonical six
- [x] `bun run typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)